### PR TITLE
Feature add validate method

### DIFF
--- a/MetaBond.Application/Feature/Communities/Commands/Create/CreateCommuntiesCommandHandler.cs
+++ b/MetaBond.Application/Feature/Communities/Commands/Create/CreateCommuntiesCommandHandler.cs
@@ -23,7 +23,14 @@ namespace MetaBond.Application.Feature.Communities.Commands
         {
 
             if (request != null)
-            { 
+            {
+                var exists = await _communitiesRepository.ValidateAsync(x => x.Name == request.Name);
+                if (exists)
+                {
+                    _logger.LogError($"The name {request.Name} already exists.");
+
+                    return ResultT<CommunitiesDTos>.Failure(Error.Failure("400", $"The name {request.Name} already exists."));
+                }
                 
                 Domain.Models.Communities communities = new()
                 {
@@ -44,7 +51,7 @@ namespace MetaBond.Application.Feature.Communities.Commands
                 
                 return ResultT<CommunitiesDTos>.Success(communitiesDTos);
             }
-            _logger.LogError("Received a null CreateCommuntiesCommand request.");
+            _logger.LogError("Received a null CreateCommunitiesCommand request.");
             return ResultT<CommunitiesDTos>.Failure(Error.Failure("400", "The request object is null"));
         }
     }

--- a/MetaBond.Application/Interfaces/Repository/ICommunitiesRepository.cs
+++ b/MetaBond.Application/Interfaces/Repository/ICommunitiesRepository.cs
@@ -3,6 +3,7 @@ using MetaBond.Domain.Models;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Linq.Expressions;
 using System.Text;
 using System.Threading.Tasks;
 
@@ -15,6 +16,6 @@ namespace MetaBond.Application.Interfaces.Repository
         Task<IEnumerable<Communities>> GetByFilterAsync(Func<Communities, bool> predicate, CancellationToken cancellationToken);
 
         Task<IEnumerable<Communities>> GetPostsAndEventsByCommunityIdAsync(Guid communitieId, CancellationToken cancellationToken);
-
+        Task<bool> ValidateAsync(Expression<Func<Communities, bool>> predicate);
     }
 }

--- a/MetaBond.Infrastructure.Persistence/Repository/CommunitiesRepository.cs
+++ b/MetaBond.Infrastructure.Persistence/Repository/CommunitiesRepository.cs
@@ -1,4 +1,5 @@
-﻿using MetaBond.Application.Interfaces.Repository;
+﻿using System.Linq.Expressions;
+using MetaBond.Application.Interfaces.Repository;
 using MetaBond.Application.Pagination;
 using MetaBond.Domain.Models;
 using MetaBond.Infrastructure.Persistence.Context;
@@ -59,5 +60,8 @@ namespace MetaBond.Infrastructure.Persistence.Repository
                                               .ToListAsync(cancellationToken);
             return query;
         }
+        public async Task<bool> ValidateAsync(Expression<Func<Communities, bool>> predicate) => 
+        await _metaBondContext.Set<Communities>().AnyAsync(predicate);
+                            
     }
 }


### PR DESCRIPTION
# Validate Community Name Uniqueness Before Creation

## Description
This PR introduces a validation check to ensure that a community name is unique before creating a new community. If the name already exists, an error is logged and returned.

## Changes
- Added a validation method in the handler:
  ```csharp
  var exists = await _communitiesRepository.ValidateAsync(x => x.Name == request.Name);
  if (exists)
  {
      _logger.LogError($"The name {request.Name} already exists.");
      return ResultT<CommunitiesDTos>.Failure(Error.Failure("400", $"The name {request.Name} already exists."));
  }
  ```
- Prevents duplicate community names from being created.
- Improves error handling and logging for better debugging.

