### PR TITLE
Refactor add joins

### DIFF
--- a/MetaBond.Application/DTOs/Posts/PostsWithCommunitiesDTos.cs
+++ b/MetaBond.Application/DTOs/Posts/PostsWithCommunitiesDTos.cs
@@ -7,7 +7,6 @@ namespace MetaBond.Application.DTOs.Posts
         string? Title,
         string? Content,
         string? ImageUrl,
-        Guid? CommunitiesId,
         Domain.Models.Communities? Communities,
         DateTime? CreatedAt
     );

--- a/MetaBond.Application/DTOs/ProgressEntry/ProgressEntryWithProgressBoardDTos.cs
+++ b/MetaBond.Application/DTOs/ProgressEntry/ProgressEntryWithProgressBoardDTos.cs
@@ -1,0 +1,10 @@
+namespace MetaBond.Application.DTOs.ProgressEntry;
+
+public record ProgressEntryWithProgressBoardDTos
+(
+    Guid ProgressEntryId,
+    Domain.Models.ProgressBoard ProgressBoard,
+    string Description,
+    DateTime CreatedAt,
+    DateTime UpdateAt
+);

--- a/MetaBond.Application/Feature/Posts/Querys/GetPostByIdCommunities/GetPostsByIdCommunitiesQueryHandler.cs
+++ b/MetaBond.Application/Feature/Posts/Querys/GetPostByIdCommunities/GetPostsByIdCommunitiesQueryHandler.cs
@@ -45,7 +45,6 @@ namespace MetaBond.Application.Feature.Posts.Querys.GetPostByIdCommunities
                     Title: x.Title,
                     Content: x.Content,
                     ImageUrl: x.Image,
-                    CommunitiesId: x.CommunitiesId,
                     Communities: x.Communities,
                     CreatedAt: x.CreatedAt
             ));

--- a/MetaBond.Application/Feature/ProgressEntry/Querys/GetByIdProgressEntryWithProgressBoard/GetProgressEntryWithBoardByIdQuery.cs
+++ b/MetaBond.Application/Feature/ProgressEntry/Querys/GetByIdProgressEntryWithProgressBoard/GetProgressEntryWithBoardByIdQuery.cs
@@ -1,0 +1,10 @@
+using System.Collections;
+using MetaBond.Application.Abstractions.Messaging;
+using MetaBond.Application.DTOs.ProgressEntry;
+
+namespace MetaBond.Application.Feature.ProgressEntry.Querys.GetByIdProgressEntryWithProgressBoard;
+
+public class GetProgressEntryWithBoardByIdQuery : IQuery<IEnumerable<ProgressEntryWithProgressBoardDTos>>
+{
+    public Guid ProgressEntryId { get; set; }
+}

--- a/MetaBond.Application/Feature/ProgressEntry/Querys/GetByIdProgressEntryWithProgressBoard/GetProgressEntryWithBoardByIdQueryHandler.cs
+++ b/MetaBond.Application/Feature/ProgressEntry/Querys/GetByIdProgressEntryWithProgressBoard/GetProgressEntryWithBoardByIdQueryHandler.cs
@@ -1,0 +1,56 @@
+using System.Security.Cryptography;
+using MetaBond.Application.Abstractions.Messaging;
+using MetaBond.Application.DTOs.ProgressBoard;
+using MetaBond.Application.DTOs.ProgressEntry;
+using MetaBond.Application.Interfaces.Repository;
+using MetaBond.Application.Utils;
+using Microsoft.Extensions.Logging;
+
+namespace MetaBond.Application.Feature.ProgressEntry.Querys.GetByIdProgressEntryWithProgressBoard;
+
+public class GetProgressEntryWithBoardByIdQueryHandler : IQueryHandler<GetProgressEntryWithBoardByIdQuery, IEnumerable<ProgressEntryWithProgressBoardDTos>>
+{
+    private readonly IProgressEntryRepository _repository;
+    private readonly ILogger<GetProgressEntryWithBoardByIdQueryHandler> _logger;
+    
+    public GetProgressEntryWithBoardByIdQueryHandler(
+        IProgressEntryRepository repository, 
+        ILogger<GetProgressEntryWithBoardByIdQueryHandler> logger)
+    {
+        _repository = repository;
+        _logger = logger;
+    }
+    
+    public async Task<ResultT<IEnumerable<ProgressEntryWithProgressBoardDTos>>> Handle(
+        GetProgressEntryWithBoardByIdQuery request, 
+        CancellationToken cancellationToken)
+    {
+        var progressEntry = await _repository.GetByIdAsync(request.ProgressEntryId);
+        if (progressEntry != null)
+        {
+          var progressEntryWithProgressBoard = await _repository.GetByIdProgressEntryWithProgressBoard(request.ProgressEntryId,cancellationToken);
+          if (!progressEntryWithProgressBoard.Any())
+          {
+              _logger.LogError("No progress board entries found for ProgressEntry ID {ProgressEntryId}", request.ProgressEntryId);
+              return ResultT<IEnumerable<ProgressEntryWithProgressBoardDTos>>.Failure(Error.Failure("400", "No related progress board entries found."));
+          }
+
+          IEnumerable<ProgressEntryWithProgressBoardDTos> progressEntryWithBoardDTos = progressEntryWithProgressBoard.Select(x => new ProgressEntryWithProgressBoardDTos
+          (
+              ProgressEntryId: x.Id,
+              ProgressBoard: x.ProgressBoard,
+              Description: x.Description,
+              CreatedAt: x.CreatedAt,
+              UpdateAt: x.UpdateAt
+          ));
+          
+          _logger.LogInformation("Successfully retrieved {Count} progress board entries for ProgressEntry ID {ProgressEntryId}", 
+              progressEntryWithBoardDTos.Count(), request.ProgressEntryId);
+
+          return ResultT<IEnumerable<ProgressEntryWithProgressBoardDTos>>.Success(progressEntryWithBoardDTos);
+        }
+        _logger.LogError("Progress entry with ID {ProgressEntryId} not found.", request.ProgressEntryId);
+        
+        return ResultT<IEnumerable<ProgressEntryWithProgressBoardDTos>>.Failure(Error.NotFound("404", "Progress entry not found."));
+    }
+}

--- a/MetaBond.Application/Interfaces/Repository/IProgressEntryRepository.cs
+++ b/MetaBond.Application/Interfaces/Repository/IProgressEntryRepository.cs
@@ -1,10 +1,5 @@
 ﻿using MetaBond.Application.Pagination;
 using MetaBond.Domain.Models;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace MetaBond.Application.Interfaces.Repository
 {
@@ -21,5 +16,7 @@ namespace MetaBond.Application.Interfaces.Repository
         Task<IEnumerable<ProgressEntry>> GetRecentEntriesAsync(int topCount, CancellationToken cancellationToken);
 
         Task<IEnumerable<ProgressEntry>> GetOrderByDescriptionAsync(CancellationToken cancellationToken);
+
+        Task<IEnumerable<ProgressEntry>> GetByIdProgressEntryWithProgressBoard(Guid progressEntry, CancellationToken cancellationToken);
     }
 }

--- a/MetaBond.Infrastructure.Persistence/Repository/ProgressEntryRepository.cs
+++ b/MetaBond.Infrastructure.Persistence/Repository/ProgressEntryRepository.cs
@@ -4,6 +4,7 @@ using MetaBond.Domain.Models;
 using MetaBond.Infrastructure.Persistence.Context;
 using Microsoft.EntityFrameworkCore;
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -24,6 +25,19 @@ namespace MetaBond.Infrastructure.Persistence.Repository
             var query = await _metaBondContext.Set<ProgressEntry>()
                                               .AsNoTracking()
                                               .CountAsync(x => x.ProgressBoardId == ProgressBoardId, cancellationToken);
+            return query;
+        }
+
+        public async Task<IEnumerable<ProgressEntry>> GetByIdProgressEntryWithProgressBoard(Guid progressEntry,
+            CancellationToken cancellationToken)
+        {
+            var query = await _metaBondContext.Set<ProgressEntry>()
+                .AsNoTracking()
+                .Where(x => x.ProgressBoardId == progressEntry)
+                .Include(x => x.ProgressBoard)
+                .AsSplitQuery()
+                .ToListAsync(cancellationToken);
+            
             return query;
         }
 

--- a/MetaBond.Presentation.Api/Controllers/V1/ProgressEntriesController.cs
+++ b/MetaBond.Presentation.Api/Controllers/V1/ProgressEntriesController.cs
@@ -4,6 +4,7 @@ using MetaBond.Application.Feature.ProgressEntry.Commands.Create;
 using MetaBond.Application.Feature.ProgressEntry.Commands.Delete;
 using MetaBond.Application.Feature.ProgressEntry.Commands.Update;
 using MetaBond.Application.Feature.ProgressEntry.Querys.GetById;
+using MetaBond.Application.Feature.ProgressEntry.Querys.GetByIdProgressEntryWithProgressBoard;
 using MetaBond.Application.Feature.ProgressEntry.Querys.GetCountByBoard;
 using MetaBond.Application.Feature.ProgressEntry.Querys.GetDateRange;
 using MetaBond.Application.Feature.ProgressEntry.Querys.GetOrderByDescription;
@@ -126,7 +127,7 @@ namespace MetaBond.Presentation.Api.Controllers.V1
             return Ok(result.Value);
         }
 
-        [HttpGet("ordered-by-desciption")]
+        [HttpGet("ordered-by-description")]
         [DisableRateLimiting]
         public async Task<IActionResult> OrderByDescriptionAsync(CancellationToken cancellationToken)
         {
@@ -136,7 +137,18 @@ namespace MetaBond.Presentation.Api.Controllers.V1
 
             return Ok(result.Value);
         }
-
+        
+        [HttpGet("{id}/progress-boards")]
+        [EnableRateLimiting("fixed")]
+        public async Task<IActionResult> GetProgressEntryWithBoard([FromRoute] Guid id,CancellationToken cancellationToken)
+        {
+            var query = new GetProgressEntryWithBoardByIdQuery { ProgressEntryId = id };
+            var result = await _mediator.Send(query,cancellationToken);
+            if (!result.IsSuccess)
+                return BadRequest(result.Error);
+            
+            return Ok(result.Value);
+        }
 
         [HttpGet("pagination")]
         [EnableRateLimiting("fixed")]


### PR DESCRIPTION
# Pull Request

## Summary of Changes

This PR includes a series of changes affecting the functionality of `ProgressEntry` and its relation to `ProgressBoard`. Below are the details of the commits made:

### Commits

- **refactor**: Remove 'id' property from communities as it's no longer necessary  
  The `id` property was removed from communities as it is no longer required in the data model.

- **feat**: Fetch ProgressEntry with related ProgressBoard by ProgressBoardId  
  A new feature was implemented to fetch `ProgressEntry` along with its related `ProgressBoard` using the `ProgressBoardId`.

- **feat**: Endpoint for joining ProgressEntry with ProgressBoard by ID with rate limiting  
  An endpoint was created to retrieve `ProgressEntry` with its related `ProgressBoard` by ID, with rate limiting enabled.

- **feat**: Add ProgressEntry DTOs  
  The necessary DTOs were added to efficiently handle `ProgressEntry` data.

- **feat**: Add handler for retrieving ProgressEntry with related ProgressBoard  
  A handler was added to retrieve `ProgressEntry` with its related `ProgressBoard`, improving the structure of the code.

## Description of Changes

- The data structure for communities was refactored by removing an unnecessary property.
- New features were implemented to fetch `ProgressEntry` along with its associated `ProgressBoard`.
- Rate limiting was added to prevent excessive use of the endpoint retrieving `ProgressEntry` data.

## Why These Changes?

These changes enhance the system's structure and functionality by enabling the fetching of related data (such as the associated `ProgressBoard` for `ProgressEntry`), optimizing queries, and adding rate limiting to prevent abuse of the endpoints.
