### PR TITLE
Fix filter progress entry

### DIFF
--- a/MetaBond.Application/Feature/ProgressEntry/Querys/GetDateRange/GetEntriesByDateRangeQuery.cs
+++ b/MetaBond.Application/Feature/ProgressEntry/Querys/GetDateRange/GetEntriesByDateRangeQuery.cs
@@ -7,6 +7,7 @@ namespace MetaBond.Application.Feature.ProgressEntry.Querys.GetDateRange
 {
     public sealed class GetEntriesByDateRangeQuery : IQuery<IEnumerable<ProgressEntryDTos>>
     {
+        public Guid ProgressBoardId { get; set; }
         public DateRangeType Range {  get; set; }
     }
 }

--- a/MetaBond.Application/Feature/ProgressEntry/Querys/GetOrderByDescription/GetOrderByDescriptionProgressEntryQuery.cs
+++ b/MetaBond.Application/Feature/ProgressEntry/Querys/GetOrderByDescription/GetOrderByDescriptionProgressEntryQuery.cs
@@ -6,6 +6,6 @@ namespace MetaBond.Application.Feature.ProgressEntry.Querys.GetOrderByDescriptio
 {
     public sealed class GetOrderByDescriptionProgressEntryQuery : IQuery<IEnumerable<ProgressEntryWithDescriptionDTos>>
     {
-
+        public Guid ProgressBoardId { get; set; }
     }
 }

--- a/MetaBond.Application/Feature/ProgressEntry/Querys/GetOrderByDescription/GetOrderByDescriptionProgressEntryQueryHandler.cs
+++ b/MetaBond.Application/Feature/ProgressEntry/Querys/GetOrderByDescription/GetOrderByDescriptionProgressEntryQueryHandler.cs
@@ -7,28 +7,20 @@ using Microsoft.Extensions.Logging;
 
 namespace MetaBond.Application.Feature.ProgressEntry.Querys.GetOrderByDescription
 {
-    internal sealed class GetOrderByDescriptionProgressEntryQueryHandler : IQueryHandler<GetOrderByDescriptionProgressEntryQuery, IEnumerable<ProgressEntryWithDescriptionDTos>>
+    internal sealed class GetOrderByDescriptionProgressEntryQueryHandler(
+        IProgressEntryRepository progressEntryRepository,
+        ILogger<GetOrderByDescriptionProgressEntryQueryHandler> logger)
+        : IQueryHandler<GetOrderByDescriptionProgressEntryQuery, IEnumerable<ProgressEntryWithDescriptionDTos>>
     {
-        private readonly IProgressEntryRepository _progressEntryRepository;
-        private readonly ILogger<GetOrderByDescriptionProgressEntryQueryHandler> _logger;
-
-        public GetOrderByDescriptionProgressEntryQueryHandler(
-            IProgressEntryRepository progressEntryRepository, 
-            ILogger<GetOrderByDescriptionProgressEntryQueryHandler> logger)
-        {
-            _progressEntryRepository = progressEntryRepository;
-            _logger = logger;
-        }
-
         public async Task<ResultT<IEnumerable<ProgressEntryWithDescriptionDTos>>> Handle(
             GetOrderByDescriptionProgressEntryQuery request, 
             CancellationToken cancellationToken)
         {
 
-            IEnumerable<Domain.Models.ProgressEntry> progressEntries = await _progressEntryRepository.GetOrderByDescriptionAsync(cancellationToken);
+            IEnumerable<Domain.Models.ProgressEntry> progressEntries = await progressEntryRepository.GetOrderByDescriptionAsync(request.ProgressBoardId,cancellationToken);
             if (progressEntries == null || !progressEntries.Any())
             {
-                _logger.LogError("No progress entries found when ordering by description.");
+                logger.LogError("No progress entries found when ordering by description.");
 
                 return ResultT<IEnumerable<ProgressEntryWithDescriptionDTos>>.Failure(Error.Failure("400", "No progress entries found for the given description order."));
             }
@@ -38,7 +30,7 @@ namespace MetaBond.Application.Feature.ProgressEntry.Querys.GetOrderByDescriptio
                 Description: x.Description
             ));
 
-            _logger.LogInformation("Successfully retrieved {Count} progress entries ordered by description.", descriptionDTos.Count());
+            logger.LogInformation("Successfully retrieved {Count} progress entries ordered by description.", descriptionDTos.Count());
 
             return ResultT<IEnumerable<ProgressEntryWithDescriptionDTos>>.Success(descriptionDTos);
         }

--- a/MetaBond.Application/Feature/ProgressEntry/Querys/GetOrderById/GetOrderByIdProgressEntryQuery.cs
+++ b/MetaBond.Application/Feature/ProgressEntry/Querys/GetOrderById/GetOrderByIdProgressEntryQuery.cs
@@ -5,6 +5,6 @@ namespace MetaBond.Application.Feature.ProgressEntry.Querys.GetOrderById
 {
     public sealed class GetOrderByIdProgressEntryQuery : IQuery<IEnumerable<ProgressEntryBasicDTos>>
     {
-
+        public Guid ProgressBoardId { get; set; }
     }
 }

--- a/MetaBond.Application/Feature/ProgressEntry/Querys/GetOrderById/GetOrderByIdProgressEntryQueryHandler.cs
+++ b/MetaBond.Application/Feature/ProgressEntry/Querys/GetOrderById/GetOrderByIdProgressEntryQueryHandler.cs
@@ -6,41 +6,35 @@ using Microsoft.Extensions.Logging;
 
 namespace MetaBond.Application.Feature.ProgressEntry.Querys.GetOrderById
 {
-    internal sealed class GetOrderByIdProgressEntryQueryHandler : IQueryHandler<GetOrderByIdProgressEntryQuery, IEnumerable<ProgressEntryBasicDTos>>
+    internal sealed class GetOrderByIdProgressEntryQueryHandler(
+        IProgressEntryRepository progressEntryRepository,
+        ILogger<GetOrderByIdProgressEntryQueryHandler> logger)
+        : IQueryHandler<GetOrderByIdProgressEntryQuery, IEnumerable<ProgressEntryBasicDTos>>
     {
-        private readonly IProgressEntryRepository _progressEntryRepository;
-        private readonly ILogger<GetOrderByIdProgressEntryQueryHandler> _logger;
-
-        public GetOrderByIdProgressEntryQueryHandler(
-            IProgressEntryRepository progressEntryRepository, 
-            ILogger<GetOrderByIdProgressEntryQueryHandler> logger)
-        {
-            _progressEntryRepository = progressEntryRepository;
-            _logger = logger;
-        }
-
         public async Task<ResultT<IEnumerable<ProgressEntryBasicDTos>>> Handle(
             GetOrderByIdProgressEntryQuery request, 
             CancellationToken cancellationToken)
         {
-            IEnumerable<Domain.Models.ProgressEntry> progressEntries = await _progressEntryRepository.GetOrderByIdAsync(cancellationToken);
-            if (!progressEntries.Any())
+            IEnumerable<Domain.Models.ProgressEntry> progressEntries = await progressEntryRepository.GetOrderByIdAsync(request.ProgressBoardId,cancellationToken);
+            List<Domain.Models.ProgressEntry> enumerable = progressEntries.ToList();
+            if (!enumerable.Any())
             {
-                _logger.LogError("No progress entries found when ordering by ID.");
+                logger.LogError("No progress entries found when ordering by ID.");
 
                 return ResultT<IEnumerable<ProgressEntryBasicDTos>>.Failure(Error.Failure("400", "No progress entries available."));
             }
 
-            IEnumerable<ProgressEntryBasicDTos> entryBasicDTos = progressEntries.Select(x => new ProgressEntryBasicDTos
+            IEnumerable<ProgressEntryBasicDTos> entryBasicDTos = enumerable.Select(x => new ProgressEntryBasicDTos
             (
                 ProgressEntryId: x.Id,
                 Description: x.Description,
                 ProgressBoardId: x.ProgressBoardId
             ));
 
-            _logger.LogInformation("Successfully retrieved {Count} progress entries ordered by ID.", entryBasicDTos.Count());
+            var progressEntryBasicDTosEnumerable = entryBasicDTos.ToList();
+            logger.LogInformation("Successfully retrieved {Count} progress entries ordered by ID.", progressEntryBasicDTosEnumerable.Count());
 
-            return ResultT<IEnumerable<ProgressEntryBasicDTos>>.Success(entryBasicDTos);
+            return ResultT<IEnumerable<ProgressEntryBasicDTos>>.Success(progressEntryBasicDTosEnumerable);
         }
     }
 }

--- a/MetaBond.Application/Feature/ProgressEntry/Querys/GetRecent/GetRecentEntriesQuery.cs
+++ b/MetaBond.Application/Feature/ProgressEntry/Querys/GetRecent/GetRecentEntriesQuery.cs
@@ -5,6 +5,7 @@ namespace MetaBond.Application.Feature.ProgressEntry.Querys.GetRecent
 {
     public sealed class GetRecentEntriesQuery : IQuery<IEnumerable<ProgressEntryDTos>>
     {
+        public Guid ProgressBoardId { get; set; }
         public int TopCount { get; set; }
     }
 }

--- a/MetaBond.Application/Interfaces/Repository/IProgressEntryRepository.cs
+++ b/MetaBond.Application/Interfaces/Repository/IProgressEntryRepository.cs
@@ -7,15 +7,15 @@ namespace MetaBond.Application.Interfaces.Repository
     {
         Task<PagedResult<ProgressEntry>> GetPagedProgressEntryAsync(int pageSize, int pageNumber, CancellationToken cancellationToken);
 
-        Task<IEnumerable<ProgressEntry>> GetOrderByIdAsync(CancellationToken cancellationToken);
+        Task<IEnumerable<ProgressEntry>> GetOrderByIdAsync(Guid progressBoardId,CancellationToken cancellationToken);
 
-        Task<IEnumerable<ProgressEntry>> GetEntriesByDateRangeAsync(DateTime startTime ,DateTime endTime,CancellationToken cancellationToken);
+        Task<IEnumerable<ProgressEntry>> GetEntriesByDateRangeAsync(Guid progressBoardId,DateTime startTime ,DateTime endTime,CancellationToken cancellationToken);
 
         Task<int> CountEntriesByBoardIdAsync(Guid id, CancellationToken cancellationToken);
 
-        Task<IEnumerable<ProgressEntry>> GetRecentEntriesAsync(int topCount, CancellationToken cancellationToken);
+        Task<IEnumerable<ProgressEntry>> GetRecentEntriesAsync(Guid progressBoardId,int topCount, CancellationToken cancellationToken);
 
-        Task<IEnumerable<ProgressEntry>> GetOrderByDescriptionAsync(CancellationToken cancellationToken);
+        Task<IEnumerable<ProgressEntry>> GetOrderByDescriptionAsync(Guid progressBoardId,CancellationToken cancellationToken);
 
         Task<IEnumerable<ProgressEntry>> GetByIdProgressEntryWithProgressBoard(Guid progressEntry, CancellationToken cancellationToken);
     }

--- a/MetaBond.Infrastructure.Persistence/Repository/ProgressEntryRepository.cs
+++ b/MetaBond.Infrastructure.Persistence/Repository/ProgressEntryRepository.cs
@@ -3,12 +3,6 @@ using MetaBond.Application.Pagination;
 using MetaBond.Domain.Models;
 using MetaBond.Infrastructure.Persistence.Context;
 using Microsoft.EntityFrameworkCore;
-using System;
-using System.Collections;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace MetaBond.Infrastructure.Persistence.Repository
 {
@@ -19,12 +13,12 @@ namespace MetaBond.Infrastructure.Persistence.Repository
         }
 
         public async Task<int> CountEntriesByBoardIdAsync(
-            Guid ProgressBoardId, 
+            Guid progressBoardId, 
             CancellationToken cancellationToken)
         {
             var query = await _metaBondContext.Set<ProgressEntry>()
                                               .AsNoTracking()
-                                              .CountAsync(x => x.ProgressBoardId == ProgressBoardId, cancellationToken);
+                                              .CountAsync(x => x.ProgressBoardId == progressBoardId, cancellationToken);
             return query;
         }
 
@@ -42,22 +36,25 @@ namespace MetaBond.Infrastructure.Persistence.Repository
         }
 
         public async Task<IEnumerable<ProgressEntry>> GetEntriesByDateRangeAsync(
+            Guid progressBoardId,
             DateTime startTime, 
             DateTime endTime, 
             CancellationToken cancellationToken)
         {
             var query = await _metaBondContext.Set<ProgressEntry>()
                                                .AsNoTracking()
+                                               .Where(x => x.ProgressBoardId == progressBoardId)
                                                .Where(x => x.CreatedAt >= startTime && x.CreatedAt <= endTime)
                                                .ToListAsync(cancellationToken);
 
             return query;
         }
 
-        public async Task<IEnumerable<ProgressEntry>> GetOrderByDescriptionAsync(CancellationToken cancellationToken)
+        public async Task<IEnumerable<ProgressEntry>> GetOrderByDescriptionAsync(Guid progressBoard,CancellationToken cancellationToken)
         {
             var query = await _metaBondContext.Set<ProgressEntry>()
                                                .AsNoTracking()
+                                               .Where(x => x.ProgressBoardId == progressBoard)
                                                .OrderBy(x => x.Description)
                                                .ToListAsync(cancellationToken);
 
@@ -65,23 +62,26 @@ namespace MetaBond.Infrastructure.Persistence.Repository
         }
 
         public async Task<IEnumerable<ProgressEntry>> GetRecentEntriesAsync(
+            Guid progressBoard,
             int topCount, 
             CancellationToken cancellationToken)
         {
             var query = await _metaBondContext.Set<ProgressEntry>()
                                                .AsNoTracking()
+                                               .Where(x => x.ProgressBoardId == progressBoard)
                                                .OrderByDescending(x => x.CreatedAt)
-                                               .Take(topCount)
+                                                .Take(topCount)
                                                .ToListAsync(cancellationToken);
 
             return query;
         }
 
-        public async Task<IEnumerable<ProgressEntry>> GetOrderByIdAsync(CancellationToken cancellationToken)
+        public async Task<IEnumerable<ProgressEntry>> GetOrderByIdAsync(Guid progressBoardId,CancellationToken cancellationToken)
         {
 
             var query = await _metaBondContext.Set<ProgressEntry>()
                                                .AsNoTracking()
+                                               .Where(x => x.ProgressBoardId == progressBoardId)
                                                .OrderBy(x => x.Id)
                                                .ToListAsync(cancellationToken);
 


### PR DESCRIPTION
# Pull Request: Add ProgressBoardId to Queries and Endpoints

## Description
This PR introduces the **ProgressBoardId** parameter across various queries and endpoints in the ProgressEntry module. Additionally, it standardizes parameter naming conventions for improved consistency and maintainability.

## Changes
- **Feature:** Added `ProgressBoardId` to multiple queries to enhance filtering capabilities.
- **Refactor:** Standardized parameter names for better clarity.
- **Fix:** Adjusted `GetByIdProgressEntryWithProgressBoard` to correctly filter by `Id` instead of `ProgressBoardId`.
- **Enhancement:** Improved query readability and consistency.

## Why is this needed?
- Enables more precise filtering by linking queries directly to a **ProgressBoard**.
- Improves parameter naming conventions for better readability and maintainability.
- Fixes an issue in `GetByIdProgressEntryWithProgressBoard` where filtering was incorrect.
- Enhances query performance and code clarity.

## Checklist
- [x] Code compiles without errors
- [x] Unit tests pass successfully
- [x] API responses return expected results
- [x] Documentation updated if necessary
