### PR TITLE
Feature add community manager repository

### DIFF
--- a/MetaBond.Application/Interfaces/Repository/ICommunityManagerRepository.cs
+++ b/MetaBond.Application/Interfaces/Repository/ICommunityManagerRepository.cs
@@ -1,0 +1,22 @@
+using System.Linq.Expressions;
+using MetaBond.Application.Pagination;
+using MetaBond.Domain.Models;
+
+namespace MetaBond.Application.Interfaces.Repository;
+
+public interface ICommunityManagerRepository : IGenericRepository<CommunityManager>
+{
+    Task CreateCommunityManagerAsync(CommunityManager communityManager, CancellationToken cancellationToken);
+    
+    Task<PagedResult<CommunityManager>> GetPagedAsync(int page, int pageSize, CancellationToken cancellationToken);
+
+    Task<bool> ExistsAsync(Expression<Func<CommunityManager, bool>> predicate, CancellationToken cancellationToken);
+
+
+    Task<bool> IsUserCommunityManagerAsync(Guid userId, Guid communityId, CancellationToken cancellationToken);
+
+    Task<List<CommunityManager>> GetByUserIdAsync(Guid userId, CancellationToken cancellationToken);
+
+    Task<List<CommunityManager>> GetByCommunityIdAsync(Guid communityId, CancellationToken cancellationToken);
+
+}

--- a/MetaBond.Infrastructure.Persistence/DependecyInjection.cs
+++ b/MetaBond.Infrastructure.Persistence/DependecyInjection.cs
@@ -44,6 +44,8 @@ namespace MetaBond.Infrastructure.Persistence
             services.AddTransient<IProgressBoardRepository, ProgressBoardRepository>();
             services.AddTransient<IEventParticipationRepository, EventParticipationRepository>();
             services.AddTransient<IUserRepository, UserRepository>();
+            services.AddTransient<IAdminRepository, AdminRepository>();
+            services.AddTransient<ICommunityManagerRepository, CommunityManagerRepositoryRepository>();
             #endregion
 
         }

--- a/MetaBond.Infrastructure.Persistence/Repository/CommunityManagerRepositoryRepository.cs
+++ b/MetaBond.Infrastructure.Persistence/Repository/CommunityManagerRepositoryRepository.cs
@@ -1,0 +1,69 @@
+using System.Linq.Expressions;
+using MetaBond.Application.Interfaces.Repository;
+using MetaBond.Application.Pagination;
+using MetaBond.Domain.Models;
+using MetaBond.Infrastructure.Persistence.Context;
+using Microsoft.EntityFrameworkCore;
+
+namespace MetaBond.Infrastructure.Persistence.Repository;
+
+public class CommunityManagerRepositoryRepository(MetaBondContext metaBondContext)
+    : GenericRepository<CommunityManager>(metaBondContext), ICommunityManagerRepository
+{
+    public async Task CreateCommunityManagerAsync(CommunityManager communityManager, CancellationToken cancellationToken)
+    {
+        await _metaBondContext.Set<CommunityManager>().AddAsync(communityManager, cancellationToken);
+    }
+
+    public async Task<PagedResult<Domain.Models.CommunityManager>> GetPagedAsync(int page, int pageSize, CancellationToken cancellationToken)
+    {
+        var totalRecord = await _metaBondContext.Set<CommunityManager>()
+            .AsNoTracking()
+            .CountAsync(cancellationToken);
+
+        var pagedCommunityManager = await _metaBondContext.Set<CommunityManager>()
+            .AsNoTracking()
+            .OrderBy(cm => cm.Id)
+            .Skip((page - 1) * pageSize)
+            .Take(pageSize)
+            .ToListAsync(cancellationToken);
+        
+        var pagedResult = new PagedResult<CommunityManager>(pagedCommunityManager, page, pageSize, totalRecord);
+        
+        return pagedResult;
+    }
+
+    public async Task<bool> ExistsAsync(Expression<Func<CommunityManager,bool>> predicate, CancellationToken cancellationToken)
+    {
+        return await _metaBondContext.Set<CommunityManager>()
+            .AsNoTracking()
+            .AnyAsync(predicate, cancellationToken);
+    }
+
+    public async Task<bool> IsUserCommunityManagerAsync(Guid userId, Guid communityId, CancellationToken cancellationToken)
+    {
+        return await _metaBondContext.Set<CommunityManager>()
+            .AsNoTracking()
+            .AnyAsync(cm => cm.CommunityId == communityId && cm.UserId == userId, cancellationToken);
+    }
+
+    public async Task<List<CommunityManager>> GetByUserIdAsync(Guid userId, CancellationToken cancellationToken)
+    {
+        return await _metaBondContext.Set<CommunityManager>()
+            .AsNoTracking()
+            .Where(cm => cm.UserId == userId)
+            .Include(cm => cm.User)
+            .Include(cm => cm.Community)
+            .ToListAsync(cancellationToken);
+    }
+
+    public async Task<List<CommunityManager>> GetByCommunityIdAsync(Guid communityId, CancellationToken cancellationToken)
+    {
+        return await _metaBondContext.Set<CommunityManager>()
+            .AsNoTracking()
+            .Where(cm => cm.CommunityId == communityId)
+            .Include(cm => cm.User)
+            .Include(cm => cm.Community)
+            .ToListAsync(cancellationToken);
+    }
+}


### PR DESCRIPTION
# Pull Request: Implement and Register `CommunityManagerRepository`

## Summary

This pull request introduces the implementation of the `CommunityManagerRepository` class along with its registration in the dependency injection container. It includes basic data access operations such as create, exists check, and retrieving all community managers by user.

## Changes Introduced

- Implemented `CommunityManagerRepository` class
- Added methods:
  - `CreateCommunityManagerAsync`
  - `ExistsAsync`
  - `GetPagedAsync`
  - `GetByUserIdAsync`
- Registered `ICommunityManagerRepository` in the DI container


## Context

This is part of the community module of MetaBond. The repository handles data access for `CommunityManager` entities, supporting user-community management features.

