### PR TITLE
Feature add userid to reward dto

### DIFF
--- a/MetaBond.Application/DTOs/Account/User/UserRewardsDTos.cs
+++ b/MetaBond.Application/DTOs/Account/User/UserRewardsDTos.cs
@@ -1,0 +1,3 @@
+namespace MetaBond.Application.DTOs.Account.User;
+
+public sealed record UserRewardsDTos(Guid UserId, string? FirstName, string? LastName);

--- a/MetaBond.Application/DTOs/Communities/PostsAndEventsDTos.cs
+++ b/MetaBond.Application/DTOs/Communities/PostsAndEventsDTos.cs
@@ -6,7 +6,7 @@
         string? Name,
         string? Category,
         DateTime CreatedAt,
-        ICollection<Domain.Models.Posts> Posts,
-        ICollection<Domain.Models.Events> Events
+        IEnumerable<Domain.Models.Posts> Posts,
+        IEnumerable<Domain.Models.Events> Events
     );
 }

--- a/MetaBond.Application/DTOs/Rewards/RewardsDTos.cs
+++ b/MetaBond.Application/DTOs/Rewards/RewardsDTos.cs
@@ -4,6 +4,7 @@ namespace MetaBond.Application.DTOs.Rewards
     public sealed record RewardsDTos
     (
         Guid? RewardsId,
+        Guid UserId,
         string? Description,
         int? PointAwarded,
         DateTime? DateAwarded

--- a/MetaBond.Application/DTOs/Rewards/RewardsWithUserDTos.cs
+++ b/MetaBond.Application/DTOs/Rewards/RewardsWithUserDTos.cs
@@ -1,0 +1,12 @@
+using MetaBond.Application.DTOs.Account.User;
+
+namespace MetaBond.Application.DTOs.Rewards;
+
+public sealed record RewardsWithUserDTos
+(
+    Guid? RewardsId,
+    UserRewardsDTos User,
+    string? Description,
+    int? PointAwarded,
+    DateTime? DateAwarded
+);

--- a/MetaBond.Application/Feature/Communities/Query/GetPostsAndEvents/GetCommunityDetailsByIdQueryHandler.cs
+++ b/MetaBond.Application/Feature/Communities/Query/GetPostsAndEvents/GetCommunityDetailsByIdQueryHandler.cs
@@ -1,7 +1,7 @@
 ﻿using MetaBond.Application.Abstractions.Messaging;
 using MetaBond.Application.DTOs.Communities;
-using MetaBond.Application.Feature.Communities.Query.GetPostsAndEvents;
 using MetaBond.Application.Interfaces.Repository;
+using MetaBond.Application.Mapper;
 using MetaBond.Application.Utils;
 using MetaBond.Domain.Models;
 using Microsoft.Extensions.Caching.Distributed;
@@ -47,26 +47,10 @@ namespace MetaBond.Application.Feature.Communities.Query.GetPostsAndEvents;
             }
             
             var postsPaged = await postsRepository.GetPagedPostsAsync(request.PageNumber, request.PageSize,cancellationToken);
-            var postsModel = postsPaged.Items!.Select(x => new Domain.Models.Posts
-            {
-                Id = x.Id,
-                Title = x.Title,
-                Content = x.Content,
-                Image = x.Image,
-                CommunitiesId = x.CommunitiesId,
-                CreatedAt = x.CreatedAt
-            }).ToList();
+            var postsModel = postsPaged.Items!.Select(PostsMapper.ToDTos);
             
             var eventsPaged = await eventsRepository.GetPagedEventsAsync(request.PageNumber, request.PageSize,cancellationToken);
-            var eventsModel = eventsPaged.Items!.Select(x => new Domain.Models.Events
-            {
-                Id = x.Id,
-                Description = x.Description,
-                Title = x.Title,
-                DateAndTime = x.DateAndTime,
-                CreateAt = x.CreateAt,
-                CommunitiesId = x.CommunitiesId
-            }).ToList();
+            var eventsModel = eventsPaged.Items!.Select(EventsMapper.ToDTo);
             
             var dTos = withEventsAndPosts.Select(c => new PostsAndEventsDTos
             (

--- a/MetaBond.Application/Feature/Rewards/Commands/Create/CreateRewardsCommand.cs
+++ b/MetaBond.Application/Feature/Rewards/Commands/Create/CreateRewardsCommand.cs
@@ -7,5 +7,6 @@ public sealed class CreateRewardsCommand : ICommand<RewardsDTos>
 {
     public string? Description { get; set; }
 
+    public Guid UserId { get; set; }
     public int PointAwarded { get; set; }
 }

--- a/MetaBond.Application/Feature/Rewards/Commands/Create/CreateRewardsCommandHandler.cs
+++ b/MetaBond.Application/Feature/Rewards/Commands/Create/CreateRewardsCommandHandler.cs
@@ -33,6 +33,7 @@ internal sealed class CreateRewardsCommandHandler(
             RewardsDTos rewardsDTos = new
             (
                 RewardsId: rewardsModel.Id,
+                UserId: rewardsModel.UserId,
                 Description: rewardsModel.Description,
                 PointAwarded: rewardsModel.PointAwarded,
                 DateAwarded: rewardsModel.DateAwarded

--- a/MetaBond.Application/Feature/Rewards/Commands/Create/CreateRewardsCommandValidator.cs
+++ b/MetaBond.Application/Feature/Rewards/Commands/Create/CreateRewardsCommandValidator.cs
@@ -13,5 +13,8 @@ public class CreateRewardsCommandValidator : AbstractValidator<CreateRewardsComm
         RuleFor(x => x.PointAwarded)
             .NotEmpty().WithMessage("The awarded points are required and cannot be empty or null.")
             .GreaterThan(0).WithMessage("The awarded points must be greater than zero.");
+        
+        RuleFor(x => x.UserId)
+            .NotEmpty().WithMessage("The user id is required.");
     }
 }

--- a/MetaBond.Application/Feature/Rewards/Commands/Update/UpdateRewardsCommandHandler.cs
+++ b/MetaBond.Application/Feature/Rewards/Commands/Update/UpdateRewardsCommandHandler.cs
@@ -29,6 +29,7 @@ internal sealed class UpdateRewardsCommandHandler(
             RewardsDTos rewardsDTos = new
             (
                 RewardsId: reward.Id,
+                UserId:  reward.UserId,
                 Description: reward.Description,
                 PointAwarded: reward.PointAwarded,
                 DateAwarded: reward.DateAwarded

--- a/MetaBond.Application/Feature/Rewards/Commands/Update/UpdateRewardsCommandValidator.cs
+++ b/MetaBond.Application/Feature/Rewards/Commands/Update/UpdateRewardsCommandValidator.cs
@@ -17,6 +17,5 @@ public class UpdateRewardsCommandValidator : AbstractValidator<UpdateRewardsComm
         RuleFor(x => x.PointAwarded)
             .NotEmpty().WithMessage("The awarded points are required and cannot be empty or null.")
             .GreaterThan(0).WithMessage("The awarded points must be greater than zero.");
-        
     }
 }

--- a/MetaBond.Application/Feature/Rewards/Query/GetById/GetByIdRewardsQueryHandler.cs
+++ b/MetaBond.Application/Feature/Rewards/Query/GetById/GetByIdRewardsQueryHandler.cs
@@ -28,6 +28,7 @@ internal sealed class GetByIdRewardsQueryHandler(
             RewardsDTos rewardsDTos = new
             (
                 RewardsId: reward.Id,
+                UserId: reward.UserId,
                 Description: reward.Description,
                 PointAwarded: reward.PointAwarded,
                 DateAwarded: reward.DateAwarded

--- a/MetaBond.Application/Feature/Rewards/Query/GetRange/GetByDateRangeRewardQueryHandler.cs
+++ b/MetaBond.Application/Feature/Rewards/Query/GetRange/GetByDateRangeRewardQueryHandler.cs
@@ -38,6 +38,7 @@ internal sealed class GetByDateRangeRewardQueryHandler(
             IEnumerable<RewardsDTos> rewardsDTos = rewardsEnumerable.Select(x => new RewardsDTos
             (
                 RewardsId: x.Id,
+                UserId: x.UserId,
                 Description: x.Description,
                 PointAwarded: x.PointAwarded,
                 DateAwarded: x.DateAwarded

--- a/MetaBond.Application/Feature/Rewards/Query/GetRecent/GetMostRecentRewardsQueryHandler.cs
+++ b/MetaBond.Application/Feature/Rewards/Query/GetRecent/GetMostRecentRewardsQueryHandler.cs
@@ -29,6 +29,7 @@ internal sealed class GetMostRecentRewardsQueryHandler(
             RewardsDTos rewardsDTos = new
             (
                 RewardsId: rewardRecent.Id,
+                UserId: rewardRecent.UserId,
                 Description: rewardRecent.Description,
                 PointAwarded: rewardRecent.PointAwarded,
                 DateAwarded: rewardRecent.DateAwarded

--- a/MetaBond.Application/Feature/Rewards/Query/GetTop/GetTopRewardsQueryHandler.cs
+++ b/MetaBond.Application/Feature/Rewards/Query/GetTop/GetTopRewardsQueryHandler.cs
@@ -37,6 +37,7 @@ internal sealed class GetTopRewardsQueryHandler(
             IEnumerable<RewardsDTos> rewardsDTos = rewardsEnumerable.Select(x => new RewardsDTos
             (
                 RewardsId: x.Id,
+                UserId: x.UserId,
                 Description: x.Description,
                 PointAwarded: x.PointAwarded,
                 DateAwarded:  x.DateAwarded

--- a/MetaBond.Application/Feature/Rewards/Query/GetUsersByReward/GetUsersByRewardIdQuery.cs
+++ b/MetaBond.Application/Feature/Rewards/Query/GetUsersByReward/GetUsersByRewardIdQuery.cs
@@ -1,0 +1,10 @@
+using MetaBond.Application.Abstractions.Messaging;
+using MetaBond.Application.DTOs.Account.User;
+using MetaBond.Application.DTOs.Rewards;
+
+namespace MetaBond.Application.Feature.Rewards.Query.GetUsersByReward;
+
+public sealed class GetUsersByRewardIdQuery : IQuery<IEnumerable<RewardsWithUserDTos>>
+{
+    public Guid RewardsId { get; init; }
+}

--- a/MetaBond.Application/Feature/Rewards/Query/GetUsersByReward/GetUsersByRewardIdQueryHandler.cs
+++ b/MetaBond.Application/Feature/Rewards/Query/GetUsersByReward/GetUsersByRewardIdQueryHandler.cs
@@ -1,0 +1,65 @@
+using MetaBond.Application.Abstractions.Messaging;
+using MetaBond.Application.DTOs.Account.User;
+using MetaBond.Application.DTOs.Rewards;
+using MetaBond.Application.Interfaces.Repository;
+using MetaBond.Application.Mapper;
+using MetaBond.Application.Utils;
+using MetaBond.Domain.Models;
+using Microsoft.Extensions.Caching.Distributed;
+using Microsoft.Extensions.Logging;
+
+namespace MetaBond.Application.Feature.Rewards.Query.GetUsersByReward;
+
+internal sealed class GetUsersByRewardIdQueryHandler(
+    IRewardsRepository rewardsRepository,
+    ILogger<GetUsersByRewardIdQueryHandler> logger,
+    IDistributedCache decorated
+) :
+    IQueryHandler<GetUsersByRewardIdQuery,
+        IEnumerable<RewardsWithUserDTos>>
+{
+    public async Task<ResultT<IEnumerable<RewardsWithUserDTos>>> Handle(
+        GetUsersByRewardIdQuery request,
+        CancellationToken cancellationToken)
+    {
+
+        if (request.RewardsId != null)
+        {
+            var reward = await rewardsRepository.GetByIdAsync(request.RewardsId);
+            if (reward == null)
+            {
+                logger.LogWarning("Reward with ID {RewardId} not found.", request.RewardsId);
+
+                return ResultT<IEnumerable<RewardsWithUserDTos>>.Failure(
+                    Error.NotFound("404", $"Reward with ID {request.RewardsId} not found."));
+            }
+
+            var rewardsWithUser = await decorated.GetOrCreateAsync(
+                $"Get-User-By-Rewards-By-Id-{request.RewardsId}",
+                async () => await rewardsRepository.GetUsersByRewardIdAsync(request.RewardsId, cancellationToken),
+                cancellationToken: cancellationToken);
+
+            IEnumerable<Domain.Models.Rewards> rewardsEnumerable = rewardsWithUser.ToList();
+            if (!rewardsEnumerable.Any())
+            {
+                logger.LogWarning("No users associated with reward ID {RewardId}.", request.RewardsId);
+
+                return ResultT<IEnumerable<RewardsWithUserDTos>>.Failure(
+                    Error.NotFound("404", $"No users associated with reward ID {request.RewardsId}."));
+            }
+
+            IEnumerable<RewardsWithUserDTos> rewardsWithUserDTos = rewardsEnumerable.Select(RewardsMapper.ToDto);
+
+            var rewardsWithUserDTosEnumerable = rewardsWithUserDTos.ToList();
+            
+            logger.LogInformation("Retrieved {Count} users associated with reward ID {RewardId}.",
+                rewardsWithUserDTosEnumerable.Count(), request.RewardsId);
+
+            return ResultT<IEnumerable<RewardsWithUserDTos>>.Success(rewardsWithUserDTosEnumerable);
+        }
+
+        logger.LogWarning("Request received with null RewardsId.");
+        return ResultT<IEnumerable<RewardsWithUserDTos>>.Failure(
+            Error.Failure("404", "Reward ID must be provided."));
+    }
+}

--- a/MetaBond.Application/Feature/Rewards/Query/Pagination/GetPagedRewardsQueryHandler.cs
+++ b/MetaBond.Application/Feature/Rewards/Query/Pagination/GetPagedRewardsQueryHandler.cs
@@ -41,6 +41,7 @@ internal sealed class GetPagedRewardsQueryHandler(
             var rewardsDto = pagedRewards.Items!.Select(x => new RewardsDTos
             (
                 RewardsId: x.Id,
+                UserId: x.UserId,
                 Description: x.Description,
                 PointAwarded: x.PointAwarded,
                 DateAwarded: x.DateAwarded

--- a/MetaBond.Application/Interfaces/Repository/IRewardsRepository.cs
+++ b/MetaBond.Application/Interfaces/Repository/IRewardsRepository.cs
@@ -19,5 +19,7 @@ namespace MetaBond.Application.Interfaces.Repository
         Task<int> CountRewardsAsync(CancellationToken cancellationToken);
 
         Task<IEnumerable<Rewards>> GetTopRewardsByPointsAsync(int topCount, CancellationToken cancellationToken);
+
+        Task<IEnumerable<Rewards>> GetUsersByRewardIdAsync(Guid  rewardId, CancellationToken cancellationToken);
     }
 }

--- a/MetaBond.Application/Mapper/EventsMapper.cs
+++ b/MetaBond.Application/Mapper/EventsMapper.cs
@@ -1,0 +1,19 @@
+using MetaBond.Domain.Models;
+
+namespace MetaBond.Application.Mapper;
+
+public static class EventsMapper
+{
+    public static Events ToDTo(Events events)
+    {
+        return new ()
+        {
+            Id = events.Id,
+            Description = events.Description,
+            Title = events.Title,
+            DateAndTime = events.DateAndTime,
+            CreateAt = events.CreateAt,
+            CommunitiesId = events.CommunitiesId
+        };
+    }
+}

--- a/MetaBond.Application/Mapper/PostsMapper.cs
+++ b/MetaBond.Application/Mapper/PostsMapper.cs
@@ -1,0 +1,21 @@
+using MetaBond.Domain.Models;
+
+namespace MetaBond.Application.Mapper;
+
+public static class PostsMapper
+{
+    public static Domain.Models.Posts ToDTos(Domain.Models.Posts  posts)
+    {
+
+        return new Posts
+        {
+            Id = posts.Id,
+            Title = posts.Title,
+            Content = posts.Content,
+            Image = posts.Image,
+            CommunitiesId = posts.CommunitiesId,
+            CreatedAt = posts.CreatedAt
+        };
+
+    }
+}

--- a/MetaBond.Application/Mapper/RewardsMapper.cs
+++ b/MetaBond.Application/Mapper/RewardsMapper.cs
@@ -1,0 +1,24 @@
+using MetaBond.Application.DTOs.Account.User;
+using MetaBond.Application.DTOs.Rewards;
+using MetaBond.Domain.Models;
+
+namespace MetaBond.Application.Mapper;
+
+public static class RewardsMapper
+{
+    public static RewardsWithUserDTos ToDto(Rewards x)
+    {
+        return new RewardsWithUserDTos(
+
+            RewardsId: x.Id,
+            User: new UserRewardsDTos(
+                UserId: x.User!.Id,
+                FirstName: x.User.FirstName,
+                LastName: x.User.LastName
+            ),
+            Description: x.Description,
+            PointAwarded: x.PointAwarded,
+            DateAwarded: x.DateAwarded
+        );
+    }
+}

--- a/MetaBond.Infrastructure.Persistence/Repository/RewardsRepository.cs
+++ b/MetaBond.Infrastructure.Persistence/Repository/RewardsRepository.cs
@@ -6,12 +6,9 @@ using Microsoft.EntityFrameworkCore;
 
 namespace MetaBond.Infrastructure.Persistence.Repository
 {
-    public class RewardsRepository : GenericRepository<Rewards>, IRewardsRepository
+    public class RewardsRepository(MetaBondContext metaBondContext)
+        : GenericRepository<Rewards>(metaBondContext), IRewardsRepository
     {
-        public RewardsRepository(MetaBondContext metaBondContext) : base(metaBondContext)
-        {
-        }
-
         public async Task<PagedResult<Rewards>> GetPagedRewardsAsync(
             int pageNumber, 
             int pageZize, 
@@ -71,6 +68,15 @@ namespace MetaBond.Infrastructure.Persistence.Repository
                                               .ToListAsync(cancellationToken);
 
             return query;
+        }
+        public async Task<IEnumerable<Rewards>> GetUsersByRewardIdAsync(Guid rewardId, CancellationToken cancellationToken)
+        {
+            return await _metaBondContext.Set<Rewards>()
+                .AsNoTracking()
+                .Where(x => x.Id == rewardId)
+                .Include(x => x.User)
+                .AsSplitQuery()
+                .ToListAsync(cancellationToken);
         }
     }
 }

--- a/MetaBond.Tests/Rewards/RewardsControllerTests.cs
+++ b/MetaBond.Tests/Rewards/RewardsControllerTests.cs
@@ -8,6 +8,7 @@ using MetaBond.Application.Feature.Rewards.Query.GetRange;
 using MetaBond.Application.Feature.Rewards.Query.GetTop;
 using MetaBond.Application.Utils;
 using MetaBond.Domain;
+using MetaBond.Domain.Models;
 using MetaBond.Presentation.Api.Controllers.V1;
 using Moq;
 
@@ -32,6 +33,7 @@ public class RewardsControllerTests
         RewardsDTos rewardsDTos = new
         (
             RewardsId: Guid.NewGuid(),
+            UserId: Guid.NewGuid(), 
             Description: createRewardsCommand.Description,
             PointAwarded: createRewardsCommand.PointAwarded,
             DateAwarded: DateTime.Now
@@ -99,6 +101,7 @@ public class RewardsControllerTests
         RewardsDTos rewardsDTos = new
         (
             RewardsId: command.RewardsId,
+            UserId: Guid.NewGuid(),
             Description: command.Description,
             PointAwarded: command.PointAwarded,
             DateAwarded: DateTime.Now
@@ -135,6 +138,7 @@ public class RewardsControllerTests
         RewardsDTos rewardsDTos = new
         (
             RewardsId: query.RewardsId,
+            UserId: Guid.NewGuid(),
             Description: "Description",
             PointAwarded: 12,
             DateAwarded: DateTime.Now
@@ -172,6 +176,7 @@ public class RewardsControllerTests
             new RewardsDTos
             (
                 RewardsId: Guid.NewGuid(),
+                UserId:  Guid.NewGuid(),
                 Description: "Description",
                 PointAwarded: 12,
                 DateAwarded: DateTime.Now
@@ -210,6 +215,7 @@ public class RewardsControllerTests
             new RewardsDTos
             (
                 RewardsId: Guid.NewGuid(),
+                UserId: Guid.NewGuid(),
                 Description: "Description",
                 PointAwarded: 12,
                 DateAwarded: DateTime.Now


### PR DESCRIPTION
# Pull Request: Enhance Reward Mapping and User Association Functionality

## Summary

This PR introduces several enhancements and refactors to improve reward-related data handling, user association, and mapping logic. It includes DTO updates, new mappers, query/command handlers, and corresponding unit tests.

---

## What's New

### Features
- **Add `PostsMapper`, `EventsMapper`, and `RewardsMapper`** to centralize and streamline entity-to-DTO conversions.
- **Introduce `UserRewardsDTO` and `RewardsWithUserDTOs`** for better structure in reward-to-user response mapping.
- **Add `GetUsersByReward` query and handler** to support fetching rewards tied to specific users.
- **Implement `GetUsersByRewardIdAsync` repository method** to efficiently retrieve rewards with their associated users.
- **Add `UserId` support in commands, queries, and handlers** for filtering and linking rewards to users.

### Tests
- Updated unit tests to include and validate the new `UserId` property within `RewardsDTOs`.

### Refactors
- Changed `ICollection` to `IEnumerable` in `PostsAndEventsDTOs` for better flexibility and compatibility.
- Refactored `PostsMapper` and `EventsMapper` methods for consistency and maintainability.


