### PR TITLE
Feature add userid to commands controller

### DIFF
--- a/MetaBond.Presentation.Api/Controllers/V1/CommunitiesController.cs
+++ b/MetaBond.Presentation.Api/Controllers/V1/CommunitiesController.cs
@@ -42,9 +42,9 @@ namespace MetaBond.Presentation.Api.Controllers.V1
             return Ok(result.Value);
         }
 
-        [HttpPut("update/{id}")]
+        [HttpPut]
         [EnableRateLimiting("fixed")]
-        public async Task<IActionResult> UpdateAsync([FromRoute] Guid id, [FromBody] UpdateCommunitiesCommand updateCommand,CancellationToken cancellationToken)
+        public async Task<IActionResult> UpdateAsync([FromBody] UpdateCommunitiesCommand updateCommand,CancellationToken cancellationToken)
         {
             var result = await mediator.Send(updateCommand,cancellationToken);
             if (!result.IsSuccess)

--- a/MetaBond.Presentation.Api/Controllers/V1/EventsController.cs
+++ b/MetaBond.Presentation.Api/Controllers/V1/EventsController.cs
@@ -46,11 +46,10 @@ namespace MetaBond.Presentation.Api.Controllers.V1
             return Ok(result.Value);
         }
 
-        [HttpPut("{id}")]
+        [HttpPut]
         [EnableRateLimiting("fixed")]
-        public async Task<IActionResult> UpdateAsync([FromRoute] Guid id, [FromBody] UpdateEventsCommand updateEventsCommand,CancellationToken cancellationToken)
+        public async Task<IActionResult> UpdateAsync([FromBody] UpdateEventsCommand updateEventsCommand,CancellationToken cancellationToken)
         {
-            //updateEventsCommand.Id = id;
             var result = await mediator.Send(updateEventsCommand,cancellationToken);
             if (!result.IsSuccess)
                 return NotFound(result.Error);

--- a/MetaBond.Presentation.Api/Controllers/V1/FriendshipController.cs
+++ b/MetaBond.Presentation.Api/Controllers/V1/FriendshipController.cs
@@ -60,12 +60,10 @@ namespace MetaBond.Presentation.Api.Controllers.V1
             return Ok(result);
         }
 
-        [HttpPut("{id}")]
+        [HttpPut]
         [DisableRateLimiting]
-        public async Task<IActionResult> UpdateAsync([FromRoute] Guid id, [FromBody] UpdateFriendshipCommand updateFriendshipCommand,CancellationToken cancellationToken)
+        public async Task<IActionResult> UpdateAsync([FromBody] UpdateFriendshipCommand updateFriendshipCommand,CancellationToken cancellationToken)
         {
-            updateFriendshipCommand.Id = id;
-
             var result = await mediator.Send(updateFriendshipCommand,cancellationToken);
             if (!result.IsSuccess)
                 return NotFound(result.Error);

--- a/MetaBond.Presentation.Api/Controllers/V1/ParticipationInEventController.cs
+++ b/MetaBond.Presentation.Api/Controllers/V1/ParticipationInEventController.cs
@@ -26,9 +26,9 @@ namespace MetaBond.Presentation.Api.Controllers.V1
             return Ok(result);
         }
 
-        [HttpPut("{id}")]
+        [HttpPut]
         [EnableRateLimiting("fixed")]
-        public async Task<IActionResult> UpdateAsync([FromRoute] Guid id, [FromBody] UpdateParticipationInEventCommand updateParticipationInEventCommand,CancellationToken cancellationToken)
+        public async Task<IActionResult> UpdateAsync([FromBody] UpdateParticipationInEventCommand updateParticipationInEventCommand,CancellationToken cancellationToken)
         {
             var result = await mediator.Send(updateParticipationInEventCommand,cancellationToken);
             if (!result.IsSuccess) 

--- a/MetaBond.Presentation.Api/Controllers/V1/ProgressBoardController.cs
+++ b/MetaBond.Presentation.Api/Controllers/V1/ProgressBoardController.cs
@@ -22,20 +22,18 @@ namespace MetaBond.Presentation.Api.Controllers.V1
     {
         [HttpPost]
         [DisableRateLimiting]
-        public async Task<IActionResult> CreateAsync([FromBody] Guid communitiesId,CancellationToken cancellationToken)
+        public async Task<IActionResult> CreateAsync([FromBody] CreateProgressBoardCommand command,CancellationToken cancellationToken)
         {
-            var query = new CreateProgressBoardCommand { CommunitiesId = communitiesId };
-
-            var result = await mediator.Send(query,cancellationToken);
+            var result = await mediator.Send(command,cancellationToken);
             if(!result.IsSuccess)
                 return BadRequest(result.Error);
 
             return Ok(result.Value);
         }
 
-        [HttpPut("{id}")]
+        [HttpPut]
         [DisableRateLimiting]
-        public async Task<IActionResult> UpdateAsync([FromRoute] Guid id,[FromBody] UpdateProgressBoardCommand updateProgressBoardCommand,CancellationToken cancellationToken)
+        public async Task<IActionResult> UpdateAsync([FromBody] UpdateProgressBoardCommand updateProgressBoardCommand,CancellationToken cancellationToken)
         {
             var result = await mediator.Send(updateProgressBoardCommand,cancellationToken);
             if(!result.IsSuccess)

--- a/MetaBond.Presentation.Api/Controllers/V1/ProgressEntriesController.cs
+++ b/MetaBond.Presentation.Api/Controllers/V1/ProgressEntriesController.cs
@@ -33,9 +33,9 @@ namespace MetaBond.Presentation.Api.Controllers.V1
             return Ok(result.Value);
         }
 
-        [HttpPut("{id}")]
+        [HttpPut]
         [DisableRateLimiting]
-        public async Task<IActionResult> UpdateAsync([FromRoute] Guid id, [FromBody] UpdateProgressEntryCommand updateProgressEntry,CancellationToken cancellationToken)
+        public async Task<IActionResult> UpdateAsync([FromBody] UpdateProgressEntryCommand updateProgressEntry,CancellationToken cancellationToken)
         {
             var result = await mediator.Send(updateProgressEntry,cancellationToken);
             if(!result.IsSuccess)

--- a/MetaBond.Presentation.Api/Controllers/V1/RewardsController.cs
+++ b/MetaBond.Presentation.Api/Controllers/V1/RewardsController.cs
@@ -51,12 +51,10 @@ namespace MetaBond.Presentation.Api.Controllers.V1
             return Ok(result.Value);
         }
 
-        [HttpPut("{id}")]
+        [HttpPut]
         [DisableRateLimiting]
-        public async Task<IActionResult> UpdateAsync([FromRoute] Guid id, [FromBody] UpdateRewardsCommand rewardsCommand,CancellationToken cancellationToken)
+        public async Task<IActionResult> UpdateAsync([FromBody] UpdateRewardsCommand rewardsCommand,CancellationToken cancellationToken)
         {
-            rewardsCommand.RewardsId = id;
-
             var result = await _mediator.Send(rewardsCommand,cancellationToken);
             if (!result.IsSuccess)
                 return NotFound(result.Error);

--- a/MetaBond.Tests/Communities/CommunitiesCommandHandlerTests.cs
+++ b/MetaBond.Tests/Communities/CommunitiesCommandHandlerTests.cs
@@ -105,7 +105,7 @@ public class CommunitiesCommandHandlerTests
         var communitiesController = new CommunitiesController(_mediatorMock.Object);
         
         //Act
-        var result = communitiesController.UpdateAsync(Guid.NewGuid(), communitiesCommand,CancellationToken.None);
+        var result = communitiesController.UpdateAsync(communitiesCommand, CancellationToken.None);
         
         //Assert
         Assert.NotNull(result);

--- a/MetaBond.Tests/Events/EventsControllerTests.cs
+++ b/MetaBond.Tests/Events/EventsControllerTests.cs
@@ -118,7 +118,7 @@ public class EventsControllerTests
         
         //Act
 
-        var resultController = eventsController.UpdateAsync(Guid.NewGuid(), eventsCommand, CancellationToken.None);
+        var resultController = eventsController.UpdateAsync(eventsCommand, CancellationToken.None);
 
         //Assert
         

--- a/MetaBond.Tests/Friendship/FriendshipControllerTests.cs
+++ b/MetaBond.Tests/Friendship/FriendshipControllerTests.cs
@@ -75,7 +75,7 @@ public class FriendshipControllerTests
 
         // Act
 
-        var resultController = friendshipController.UpdateAsync(updateFriendshipCommand.Id,updateFriendshipCommand, CancellationToken.None);
+        var resultController = friendshipController.UpdateAsync(updateFriendshipCommand, CancellationToken.None);
 
         // Assert
         Assert.NotSame(expectedResult, resultController);

--- a/MetaBond.Tests/ParticipationInEventTests/ParticipationInEventTests.cs
+++ b/MetaBond.Tests/ParticipationInEventTests/ParticipationInEventTests.cs
@@ -74,7 +74,7 @@ public class ParticipationInEventTests
         
         //Act
 
-        var resultController = participationInEventController.UpdateAsync(updateParticipationInEventCommand.Id, updateParticipationInEventCommand, CancellationToken.None);
+        var resultController = participationInEventController.UpdateAsync(updateParticipationInEventCommand, CancellationToken.None);
 
         // Assert
         

--- a/MetaBond.Tests/ProgressBoard/ProgressBoardControllerTests.cs
+++ b/MetaBond.Tests/ProgressBoard/ProgressBoardControllerTests.cs
@@ -49,7 +49,7 @@ public class ProgressBoardControllerTests
 
         // Act
 
-        var resultController = progressBoardController.CreateAsync(createProgressBoardCommand.CommunitiesId, CancellationToken.None);
+        var resultController = progressBoardController.CreateAsync(createProgressBoardCommand, CancellationToken.None);
 
         // Assert
         Assert.NotNull(resultController);
@@ -85,7 +85,7 @@ public class ProgressBoardControllerTests
         
         // Act
 
-        var resultController =progressBoardController.UpdateAsync(command.ProgressBoardId,command, CancellationToken.None);
+        var resultController =progressBoardController.UpdateAsync(command, CancellationToken.None);
 
         // Assert
 

--- a/MetaBond.Tests/ProgressEntry/ProgressEntryControllerTests.cs
+++ b/MetaBond.Tests/ProgressEntry/ProgressEntryControllerTests.cs
@@ -117,7 +117,7 @@ public class ProgressEntryControllerTests
         
         // Act
 
-        var resultController = progressBoardController.UpdateAsync(command.ProgressEntryId,command, CancellationToken.None);
+        var resultController = progressBoardController.UpdateAsync(command, CancellationToken.None);
 
         // Assert
         

--- a/MetaBond.Tests/Rewards/RewardsControllerTests.cs
+++ b/MetaBond.Tests/Rewards/RewardsControllerTests.cs
@@ -116,7 +116,7 @@ public class RewardsControllerTests
         
         // Act
     
-        var resultController = rewardsController.UpdateAsync(command.RewardsId, command, CancellationToken.None);
+        var resultController = rewardsController.UpdateAsync(command, CancellationToken.None);
 
         // Assert
         


### PR DESCRIPTION
# Pull Request: Remove Redundant `Id` Parameter from Update Methods

## Summary

This PR refactors the update methods across all controllers to remove the redundant `Id` parameter from the method signature. It also updates the corresponding unit tests to reflect this change.

---

## What's Changed

### Refactor
- Removed the `Id` parameter from all `Update` controller methods.
- Simplified method signatures by relying on the `Id` already present within the DTOs.

### Tests
- Updated unit tests to align with the new method signatures.
- Removed unnecessary `Id` values being passed explicitly to update method calls in test cases.