### PR TITLE
Add pagination validation helper and reusable entity fetch by ID

### DIFF
--- a/MetaBond.Application/Feature/Communities/Commands/Delete/DeleteCommunitiesCommandHandler.cs
+++ b/MetaBond.Application/Feature/Communities/Commands/Delete/DeleteCommunitiesCommandHandler.cs
@@ -1,4 +1,5 @@
 ﻿using MetaBond.Application.Abstractions.Messaging;
+using MetaBond.Application.Helpers;
 using MetaBond.Application.Interfaces.Repository;
 using MetaBond.Application.Utils;
 using Microsoft.Extensions.Logging;
@@ -12,16 +13,24 @@ internal sealed class DeleteCommunitiesCommandHandler(
 {
     public async Task<ResultT<Guid>> Handle(DeleteCommunitiesCommand request, CancellationToken cancellationToken)
     {
-        var communities = await communitiesRepository.GetByIdAsync(request.Id);
-        if (communities != null)
+        var communities = await EntityHelper.GetEntityByIdAsync
+        (
+            communitiesRepository.GetByIdAsync,
+            request.Id,
+            "Communities",
+            logger
+        );
+        if (communities.IsSuccess)
         {
-            await communitiesRepository.DeleteAsync(communities, cancellationToken);
+            await communitiesRepository.DeleteAsync(communities.Value, cancellationToken);
+
             logger.LogInformation("Community with ID {CommunityId} successfully deleted.", request.Id);
 
             return ResultT<Guid>.Success(request.Id);
         }
 
         logger.LogError("Community with ID {CommunityId} not found for deletion.", request.Id);
+
         return ResultT<Guid>.Failure(Error.NotFound("404", $"{request.Id} not found"));
     }
 }

--- a/MetaBond.Application/Feature/Communities/Commands/Update/UpdateCommunitiesCommand.cs
+++ b/MetaBond.Application/Feature/Communities/Commands/Update/UpdateCommunitiesCommand.cs
@@ -10,4 +10,6 @@ public class UpdateCommunitiesCommand : ICommand<CommunitiesDTos>
     public string? Name { get; set; }
 
     public string? Category { get; set; }
+    
+    public string? Description { get; set; }
 }

--- a/MetaBond.Application/Feature/Communities/Query/GetById/GetByIdCommunitiesHandler.cs
+++ b/MetaBond.Application/Feature/Communities/Query/GetById/GetByIdCommunitiesHandler.cs
@@ -1,5 +1,6 @@
 ﻿using MetaBond.Application.Abstractions.Messaging;
 using MetaBond.Application.DTOs.Communities;
+using MetaBond.Application.Helpers;
 using MetaBond.Application.Interfaces.Repository;
 using MetaBond.Application.Mapper;
 using MetaBond.Application.Utils;
@@ -17,16 +18,22 @@ public class GetByIdCommunitiesHandler(
     public async Task<ResultT<CommunitiesDTos>> Handle(GetByIdCommunitiesQuery request,
         CancellationToken cancellationToken)
     {
-        var communities = await communitiesRepository.GetByIdAsync(request.Id);
+        var communities = await EntityHelper.GetEntityByIdAsync
+        (
+            communitiesRepository.GetByIdAsync,
+            request.Id,
+            "Communities",
+            logger
+        );
 
-        if (communities is null)
+        if (!communities.IsSuccess)
         {
             logger.LogError("Community with ID {CommunityId} was not found.", request.Id);
 
             return ResultT<CommunitiesDTos>.Failure(Error.NotFound("404", $"{request.Id} not found"));
         }
 
-        var communitiesDto = CommunityMapper.MapCommunitiesDTos(communities);
+        var communitiesDto = CommunityMapper.MapCommunitiesDTos(communities.Value);
 
         logger.LogInformation("Successfully retrieved community with ID {CommunityId}.", request.Id);
 

--- a/MetaBond.Application/Feature/CommunityMembership/Query/GetCommunityMember/GetCommunityMemberQueryHandler.cs
+++ b/MetaBond.Application/Feature/CommunityMembership/Query/GetCommunityMember/GetCommunityMemberQueryHandler.cs
@@ -22,15 +22,11 @@ internal sealed class GetCommunityMemberQueryHandler(
     public async Task<ResultT<PagedResult<CommunityMembersDto>>> Handle(GetCommunityMemberQuery request,
         CancellationToken cancellationToken)
     {
-        if (request.PageNumber <= 0 || request.PageSize <= 0)
-        {
-            logger.LogError("Invalid pagination params: PageNumber={PageNumber}, PageSize={PageSize}",
-                request.PageNumber, request.PageSize);
+        var validationPagination = PaginationHelper.ValidatePagination<CommunityMembersDto>(request.PageNumber,
+            request.PageSize, logger);
 
-            return ResultT<PagedResult<CommunityMembersDto>>.Failure(
-                Error.Failure("400", "Page number and page size must be greater than zero.")
-            );
-        }
+        if (!validationPagination.IsSuccess)
+            return validationPagination;
 
         var communityResult = await EntityHelper.GetEntityByIdAsync(communitiesRepository.GetByIdAsync,
             request.CommunityId ?? Guid.Empty,

--- a/MetaBond.Application/Feature/CommunityMembership/Query/GetUserCommunities/GetUserCommunitiesQueryHandler.cs
+++ b/MetaBond.Application/Feature/CommunityMembership/Query/GetUserCommunities/GetUserCommunitiesQueryHandler.cs
@@ -29,6 +29,12 @@ internal sealed class GetUserCommunitiesQueryHandler(
                 "Invalid request: GetUserCommunitiesQuery cannot be null."));
         }
 
+        var validationPagination = PaginationHelper.ValidatePagination<CommunitiesDTos>(request.PageNumber,
+            request.PageSize, logger);
+
+        if (!validationPagination.IsSuccess)
+            return validationPagination;
+
         var userResult = await EntityHelper.GetEntityByIdAsync(userRepository.GetByIdAsync,
             request.UserId ?? Guid.Empty,
             "User",

--- a/MetaBond.Application/Feature/Events/Commands/Delete/DeleteEventsCommandHandler.cs
+++ b/MetaBond.Application/Feature/Events/Commands/Delete/DeleteEventsCommandHandler.cs
@@ -1,4 +1,6 @@
 ﻿using MetaBond.Application.Abstractions.Messaging;
+using MetaBond.Application.DTOs.Events;
+using MetaBond.Application.Helpers;
 using MetaBond.Application.Interfaces.Repository;
 using MetaBond.Application.Utils;
 using Microsoft.Extensions.Logging;
@@ -14,10 +16,14 @@ namespace MetaBond.Application.Feature.Events.Commands.Delete
             DeleteEventsCommand request,
             CancellationToken cancellationToken)
         {
-            var events = await eventsRepository.GetByIdAsync(request.Id);
-            if (events != null)
+            var events = await EntityHelper.GetEntityByIdAsync(eventsRepository.GetByIdAsync,
+                request.Id,
+                "Events",
+                logger);
+
+            if (events.IsSuccess)
             {
-                await eventsRepository.DeleteAsync(events, cancellationToken);
+                await eventsRepository.DeleteAsync(events.Value, cancellationToken);
 
                 logger.LogInformation("Event with ID {EventId} was successfully deleted.", request.Id);
 

--- a/MetaBond.Application/Feature/Events/Query/FilterByDateRange/FilterByDateRangeEventsQueryHandler.cs
+++ b/MetaBond.Application/Feature/Events/Query/FilterByDateRange/FilterByDateRangeEventsQueryHandler.cs
@@ -20,6 +20,15 @@ namespace MetaBond.Application.Feature.Events.Query.FilterByDateRange
             FilterByDateRangeEventsQuery request,
             CancellationToken cancellationToken)
         {
+            var exists = await eventsRepository.ValidateAsync(x => x.Id == request.CommunitiesId, cancellationToken);
+            if (!exists)
+            {
+                logger.LogError("The community with ID {Id} does not exist.", request.CommunitiesId);
+
+                return ResultT<IEnumerable<EventsDto>>.Failure(Error.NotFound("404",
+                    $"{request.CommunitiesId} not found"));
+            }
+
             var status = FilterByDateRange(request.CommunitiesId);
             if (status.TryGetValue((request.DateRangeFilter), out var getStatusList))
             {
@@ -32,7 +41,7 @@ namespace MetaBond.Application.Feature.Events.Query.FilterByDateRange
 
                         var listsEvents = eventsLists.ToList();
                         IEnumerable<EventsDto> dTos = listsEvents.Select(EventsMapper.EventsToDto).ToList();
-                        
+
                         return dTos;
                     },
                     cancellationToken: cancellationToken);

--- a/MetaBond.Application/Feature/Events/Query/FilterByTitleCommunityId/GetEventsByTitleAndCommunityIdQueryHandler.cs
+++ b/MetaBond.Application/Feature/Events/Query/FilterByTitleCommunityId/GetEventsByTitleAndCommunityIdQueryHandler.cs
@@ -1,5 +1,6 @@
 using MetaBond.Application.Abstractions.Messaging;
 using MetaBond.Application.DTOs.Events;
+using MetaBond.Application.Helpers;
 using MetaBond.Application.Interfaces.Repository;
 using MetaBond.Application.Mapper;
 using MetaBond.Application.Utils;
@@ -19,10 +20,17 @@ public class GetEventsByTitleAndCommunityIdQueryHandler(
         GetEventsByTitleAndCommunityIdQuery request,
         CancellationToken cancellationToken)
     {
-        var communitiesId = await communitiesRepository.GetByIdAsync(request.CommunitiesId);
-        if (communitiesId is null)
+        var communitiesId = await EntityHelper.GetEntityByIdAsync
+        (
+            communitiesRepository.GetByIdAsync,
+            request.CommunitiesId,
+            "Communities",
+            logger
+        );
+        if (!communitiesId.IsSuccess)
         {
             logger.LogError($"Community with ID {request.CommunitiesId} not found.");
+
             return ResultT<IEnumerable<EventsDto>>.Failure(Error.NotFound("404", $"{request.CommunitiesId} not found"));
         }
 

--- a/MetaBond.Application/Feature/Events/Query/GetOrderById/GetOrderByIdEventsQuery.cs
+++ b/MetaBond.Application/Feature/Events/Query/GetOrderById/GetOrderByIdEventsQuery.cs
@@ -1,10 +1,5 @@
 ﻿using MetaBond.Application.Abstractions.Messaging;
 using MetaBond.Application.DTOs.Events;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace MetaBond.Application.Feature.Events.Query.GetOrderById
 {

--- a/MetaBond.Application/Feature/Events/Query/Pagination/GetPagedEventsQueryHandler.cs
+++ b/MetaBond.Application/Feature/Events/Query/Pagination/GetPagedEventsQueryHandler.cs
@@ -1,5 +1,6 @@
 ﻿using MetaBond.Application.Abstractions.Messaging;
 using MetaBond.Application.DTOs.Events;
+using MetaBond.Application.Helpers;
 using MetaBond.Application.Interfaces.Repository;
 using MetaBond.Application.Mapper;
 using MetaBond.Application.Pagination;
@@ -18,13 +19,11 @@ namespace MetaBond.Application.Feature.Events.Query.Pagination
         public async Task<ResultT<PagedResult<EventsDto>>> Handle(GetPagedEventsQuery request,
             CancellationToken cancellationToken)
         {
-            if (request.PageNumber <= 0 && request.PageSize <= 0)
-            {
-                logger.LogError("Invalid pagination parameters");
+            var validationPagination = PaginationHelper.ValidatePagination<EventsDto>(request.PageNumber,
+                request.PageSize, logger);
 
-                return ResultT<PagedResult<EventsDto>>.Failure(Error.Failure("400",
-                    "PageNumber and PageSize must be greater than 0."));
-            }
+            if (!validationPagination.IsSuccess)
+                return validationPagination;
 
             string cacheKey = $"paged-events-page-{request.PageNumber}-size-{request.PageSize}";
             var eventsPaged = await decoratedCache.GetOrCreateAsync(

--- a/MetaBond.Application/Feature/Friendship/Commands/Delete/DeleteFriendshipCommandHandler.cs
+++ b/MetaBond.Application/Feature/Friendship/Commands/Delete/DeleteFriendshipCommandHandler.cs
@@ -1,4 +1,5 @@
 ﻿using MetaBond.Application.Abstractions.Messaging;
+using MetaBond.Application.Helpers;
 using MetaBond.Application.Interfaces.Repository;
 using MetaBond.Application.Utils;
 using Microsoft.Extensions.Logging;
@@ -14,14 +15,21 @@ internal sealed class DeleteFriendshipCommandHandler(
         DeleteFriendshipCommand request,
         CancellationToken cancellationToken)
     {
-        var friendship = await friendshipRepository.GetByIdAsync(request.Id);
-        if (friendship != null)
+        var friendship =
+            await EntityHelper.GetEntityByIdAsync(friendshipRepository.GetByIdAsync,
+                request.Id,
+                "Friendship",
+                logger);
+
+        if (!friendship.IsSuccess) return ResultT<Guid>.Failure(friendship.Error!);
+
+        if (friendship.IsSuccess)
         {
-            await friendshipRepository.DeleteAsync(friendship, cancellationToken);
+            await friendshipRepository.DeleteAsync(friendship.Value, cancellationToken);
 
-            logger.LogInformation("Friendship with ID: {FriendshipId} deleted successfully.", friendship.Id);
+            logger.LogInformation("Friendship with ID: {FriendshipId} deleted successfully.", friendship.Value.Id);
 
-            return ResultT<Guid>.Success(friendship.Id);
+            return ResultT<Guid>.Success(friendship.Value.Id);
         }
 
         logger.LogError("Failed to delete friendship: ID {FriendshipId} not found.", request.Id);

--- a/MetaBond.Application/Feature/Friendship/Query/GetById/GetByIdFriendshipQueryHandler.cs
+++ b/MetaBond.Application/Feature/Friendship/Query/GetById/GetByIdFriendshipQueryHandler.cs
@@ -1,5 +1,6 @@
 ﻿using MetaBond.Application.Abstractions.Messaging;
 using MetaBond.Application.DTOs.Friendship;
+using MetaBond.Application.Helpers;
 using MetaBond.Application.Interfaces.Repository;
 using MetaBond.Application.Mapper;
 using MetaBond.Application.Utils;
@@ -17,13 +18,20 @@ internal sealed class GetByIdFriendshipQueryHandler(
         GetByIdFriendshipQuery request,
         CancellationToken cancellationToken)
     {
-        var friendship = await friendshipRepository.GetByIdAsync(request.Id);
-        if (friendship is not null)
+        var friendship =
+            await EntityHelper.GetEntityByIdAsync(friendshipRepository.GetByIdAsync,
+                request.Id,
+                "Friendship",
+                logger);
+
+        if (!friendship.IsSuccess) return ResultT<FriendshipDTos>.Failure(friendship.Error!);
+
+        if (friendship.IsSuccess)
         {
-            var friendshipDTos = FriendshipMapper.MapFriendshipDTos(friendship);
+            var friendshipDTos = FriendshipMapper.MapFriendshipDTos(friendship.Value);
 
             logger.LogInformation("Friendship retrieved successfully. ID: {FriendshipId}, Status: {Status}",
-                friendship.Id, friendship.Status);
+                friendship.Value.Id, friendship.Value.Status);
 
             return ResultT<FriendshipDTos>.Success(friendshipDTos);
         }

--- a/MetaBond.Application/Feature/Friendship/Query/GetOrderById/GetOrderByIdFriendshipQueryHandler.cs
+++ b/MetaBond.Application/Feature/Friendship/Query/GetOrderById/GetOrderByIdFriendshipQueryHandler.cs
@@ -18,6 +18,13 @@ internal sealed class GetOrderByIdFriendshipQueryHandler(
         GetOrderByIdFriendshipQuery request,
         CancellationToken cancellationToken)
     {
+        if (string.IsNullOrEmpty(request.Sort))
+        {
+            logger.LogError("Sort parameter is required.");
+
+            return ResultT<IEnumerable<FriendshipDTos>>.Failure(Error.Failure("400", "Sort parameter is required."));
+        }
+
         var friendshipSort = GetSort();
         if (friendshipSort.TryGetValue((request.Sort!.ToUpper()), out var getSortFriendship))
         {
@@ -28,8 +35,9 @@ internal sealed class GetOrderByIdFriendshipQueryHandler(
                 {
                     var sortFriendship = await getSortFriendship(cancellationToken);
 
-                    IEnumerable<FriendshipDTos> friendshipDTos = sortFriendship.Select(FriendshipMapper.MapFriendshipDTos);
-                    
+                    IEnumerable<FriendshipDTos> friendshipDTos =
+                        sortFriendship.Select(FriendshipMapper.MapFriendshipDTos);
+
                     return friendshipDTos;
                 },
                 cancellationToken: cancellationToken);

--- a/MetaBond.Application/Feature/Friendship/Query/Pagination/GetPagedFriendshipQueryHandler.cs
+++ b/MetaBond.Application/Feature/Friendship/Query/Pagination/GetPagedFriendshipQueryHandler.cs
@@ -1,5 +1,6 @@
 ﻿using MetaBond.Application.Abstractions.Messaging;
 using MetaBond.Application.DTOs.Friendship;
+using MetaBond.Application.Helpers;
 using MetaBond.Application.Interfaces.Repository;
 using MetaBond.Application.Mapper;
 using MetaBond.Application.Pagination;
@@ -19,8 +20,18 @@ internal sealed class GetPagedFriendshipQueryHandler(
         GetPagedFriendshipQuery? request,
         CancellationToken cancellationToken)
     {
+        var validationPagination = PaginationHelper.ValidatePagination<FriendshipDTos>
+        (
+            request!.PageNumber,
+            request.PageSize,
+            logger
+        );
+
+        if (!validationPagination.IsSuccess)
+            return validationPagination;
+
         string cacheKey = $"paged-friendship-page-{request!.PageNumber}-size-{request.PageSize}";
-        
+
         var pagedFriendship = await decoratedCache.GetOrCreateAsync(
             cacheKey,
             async () =>

--- a/MetaBond.Application/Feature/Interest/Query/GetInterestsByName/GetInterestByNameQueryHandler.cs
+++ b/MetaBond.Application/Feature/Interest/Query/GetInterestsByName/GetInterestByNameQueryHandler.cs
@@ -22,15 +22,15 @@ internal sealed class GetInterestByNameQueryHandler(
         if (string.IsNullOrEmpty(request.InterestName))
         {
             logger.LogError("Interest name cannot be null or empty");
-        
+
             return ResultT<PagedResult<InterestWithUserDto>>.Failure(Error.Failure("400", "Interest name is required"));
         }
 
         var validationPaginationResult =
             PaginationHelper.ValidatePagination<InterestWithUserDto>(request.PageNumber, request.PageSize, logger);
-        if (validationPaginationResult != null)
-            return validationPaginationResult;
-        
+        if (!validationPaginationResult.IsSuccess)
+            return validationPaginationResult.Error!;
+
         if (!await interestRepository.InterestExistsAsync(request.InterestName, cancellationToken))
         {
             logger.LogError("Interest with name {InterestName} not found", request.InterestName);

--- a/MetaBond.Application/Feature/Interest/Query/GetInterestsByUser/GetInterestByUserQueryHandler.cs
+++ b/MetaBond.Application/Feature/Interest/Query/GetInterestsByUser/GetInterestByUserQueryHandler.cs
@@ -23,8 +23,8 @@ internal sealed class GetInterestByUserQueryHandler(
         // Validate pagination parameters
         var validationPaginationResult =
             PaginationHelper.ValidatePagination<InterestDTos>(request.PageNumber, request.PageSize, logger);
-        if (validationPaginationResult is not null)
-            return validationPaginationResult.Value;
+        if (!validationPaginationResult.IsSuccess)
+            return validationPaginationResult.Error!;
 
         var user = await EntityHelper.GetEntityByIdAsync(userRepository.GetByIdAsync, request.UserId, "User", logger);
         if (!user.IsSuccess)

--- a/MetaBond.Application/Feature/Interest/Query/Pagination/GetPagedInterestQueryHandler.cs
+++ b/MetaBond.Application/Feature/Interest/Query/Pagination/GetPagedInterestQueryHandler.cs
@@ -20,10 +20,10 @@ internal sealed class GetPagedInterestQueryHandler(
         CancellationToken cancellationToken)
     {
         // Validate page number and size
-        var validationResult =
+        var validationPaginationResult =
             PaginationHelper.ValidatePagination<InterestDTos>(request.PageNumber, request.PageSize, logger);
-        if (validationResult != null)
-            return validationResult;
+        if (!validationPaginationResult.IsSuccess)
+            return validationPaginationResult.Error!;
 
         var result = await cache.GetOrCreateAsync($"get-paged-interest-{request.PageNumber}-{request.PageSize}",
             async () =>

--- a/MetaBond.Application/Feature/ParticipationInEvent/Query/GetById/GetByIdParticipationInEventQueryHandler.cs
+++ b/MetaBond.Application/Feature/ParticipationInEvent/Query/GetById/GetByIdParticipationInEventQueryHandler.cs
@@ -1,5 +1,6 @@
 ﻿using MetaBond.Application.Abstractions.Messaging;
 using MetaBond.Application.DTOs.ParticipationInEventDtos;
+using MetaBond.Application.Helpers;
 using MetaBond.Application.Interfaces.Repository;
 using MetaBond.Application.Mapper;
 using MetaBond.Application.Utils;
@@ -17,14 +18,19 @@ internal sealed class GetByIdParticipationInEventQueryHandler(
         GetByIdParticipationInEventQuery request,
         CancellationToken cancellationToken)
     {
-        var participationInEvent = await repository.GetByIdAsync(request.ParticipationInEventId);
+        var participationInEvent = await EntityHelper.GetEntityByIdAsync(
+            repository.GetByIdAsync,
+            request.ParticipationInEventId,
+            "ParticipationInEvent",
+            logger
+        );
 
-        if (participationInEvent != null)
+        if (participationInEvent.IsSuccess)
         {
-            var inEventDTos = ParticipationInEventMapper.ParticipationInEventToDto(participationInEvent);
+            var inEventDTos = ParticipationInEventMapper.ParticipationInEventToDto(participationInEvent.Value);
 
             logger.LogInformation("Successfully retrieved participation with ParticipationId: {ParticipationId}.",
-                participationInEvent.Id);
+                participationInEvent.Value.Id);
 
             return ResultT<ParticipationInEventDTos>.Success(inEventDTos);
         }

--- a/MetaBond.Application/Feature/Posts/Query/GetById/GetByIdPostsQueryHandler.cs
+++ b/MetaBond.Application/Feature/Posts/Query/GetById/GetByIdPostsQueryHandler.cs
@@ -1,5 +1,6 @@
 ﻿using MetaBond.Application.Abstractions.Messaging;
 using MetaBond.Application.DTOs.Posts;
+using MetaBond.Application.Helpers;
 using MetaBond.Application.Interfaces.Repository;
 using MetaBond.Application.Mapper;
 using MetaBond.Application.Utils;
@@ -14,12 +15,16 @@ internal sealed class GetByIdPostsQueryHandler(
 {
     public async Task<ResultT<PostsDTos>> Handle(GetByIdPostsQuery request, CancellationToken cancellationToken)
     {
-        var posts = await postsRepository.GetByIdAsync(request.PostsId);
-        if (posts != null)
+        var posts = await EntityHelper.GetEntityByIdAsync(
+            postsRepository.GetByIdAsync,
+            request.PostsId,
+            "Posts",
+            logger);
+        if (posts.IsSuccess)
         {
-            PostsDTos postsDTos = PostsMapper.PostsToDto(posts);
+            PostsDTos postsDTos = PostsMapper.PostsToDto(posts.Value);
 
-            logger.LogInformation("Post retrieved successfully with ID: {PostId}", posts.Id);
+            logger.LogInformation("Post retrieved successfully with ID: {PostId}", posts.Value.Id);
 
             return ResultT<PostsDTos>.Success(postsDTos);
         }

--- a/MetaBond.Application/Feature/Posts/Query/GetFilterRecent/GetFilterRecentPostsQueryHandler.cs
+++ b/MetaBond.Application/Feature/Posts/Query/GetFilterRecent/GetFilterRecentPostsQueryHandler.cs
@@ -18,6 +18,13 @@ internal sealed class GetFilterRecentPostsQueryHandler(
         GetFilterRecentPostsQuery request,
         CancellationToken cancellationToken)
     {
+        if (request.TopCount <= 0)
+        {
+            logger.LogError("Invalid request: GetFilterRecentPostsQuery request is null.");
+
+            return ResultT<IEnumerable<PostsDTos>>.Failure(Error.Failure("400", "Invalid request"));
+        }
+
         string cacheKey = $"get-filter-recent-top-count{request.TopCount}-community-{request.CommunitiesId}";
         var result = await decoratedCache.GetOrCreateAsync(
             cacheKey,

--- a/MetaBond.Application/Feature/Posts/Query/GetFilterTitle/GetFilterTitlePostsQueryHandler.cs
+++ b/MetaBond.Application/Feature/Posts/Query/GetFilterTitle/GetFilterTitlePostsQueryHandler.cs
@@ -1,5 +1,6 @@
 ﻿using MetaBond.Application.Abstractions.Messaging;
 using MetaBond.Application.DTOs.Posts;
+using MetaBond.Application.Helpers;
 using MetaBond.Application.Interfaces.Repository;
 using MetaBond.Application.Mapper;
 using MetaBond.Application.Utils;
@@ -10,6 +11,7 @@ namespace MetaBond.Application.Feature.Posts.Query.GetFilterTitle;
 
 internal sealed class GetFilterTitlePostsQueryHandler(
     IPostsRepository postsRepository,
+    ICommunitiesRepository communitiesRepository,
     IDistributedCache decoratedCache,
     ILogger<GetFilterTitlePostsQueryHandler> logger)
     : IQueryHandler<GetFilterTitlePostsQuery, IEnumerable<PostsDTos>>
@@ -18,6 +20,16 @@ internal sealed class GetFilterTitlePostsQueryHandler(
         GetFilterTitlePostsQuery request,
         CancellationToken cancellationToken)
     {
+        var community = await EntityHelper.GetEntityByIdAsync(
+            communitiesRepository.GetByIdAsync,
+            request.CommunitiesId,
+            "Communities",
+            logger
+        );
+
+        if (!community.IsSuccess)
+            return ResultT<IEnumerable<PostsDTos>>.Failure(community.Error!);
+
         if (string.IsNullOrEmpty(request.Title))
         {
             logger.LogError("Invalid request: GetFilterTitlePostsQuery request is null.");

--- a/MetaBond.Application/Feature/ProgressBoard/Commands/Delete/DeleteProgressBoardCommandHandler.cs
+++ b/MetaBond.Application/Feature/ProgressBoard/Commands/Delete/DeleteProgressBoardCommandHandler.cs
@@ -1,4 +1,5 @@
 ﻿using MetaBond.Application.Abstractions.Messaging;
+using MetaBond.Application.Helpers;
 using MetaBond.Application.Interfaces.Repository;
 using MetaBond.Application.Utils;
 using Microsoft.Extensions.Logging;
@@ -14,15 +15,20 @@ namespace MetaBond.Application.Feature.ProgressBoard.Commands.Delete
             DeleteProgressBoardCommand request,
             CancellationToken cancellationToken)
         {
-            var progressBoard = await repository.GetByIdAsync(request.ProgressBoardId);
-            if (progressBoard != null)
+            var progressBoard = await EntityHelper.GetEntityByIdAsync(
+                repository.GetByIdAsync,
+                request.ProgressBoardId,
+                "ProgressBoard",
+                logger
+            );
+            if (progressBoard.IsSuccess)
             {
-                await repository.DeleteAsync(progressBoard, cancellationToken);
+                await repository.DeleteAsync(progressBoard.Value, cancellationToken);
 
                 logger.LogInformation("Progress board with ID: {ProgressBoardId} deleted successfully.",
-                    progressBoard.Id);
+                    progressBoard.Value.Id);
 
-                return ResultT<Guid>.Success(progressBoard.Id);
+                return ResultT<Guid>.Success(progressBoard.Value.Id);
             }
 
             logger.LogError("Failed to delete progress board. ID: {ProgressBoardId} not found.",

--- a/MetaBond.Application/Feature/ProgressBoard/Query/GetCount/GetCountProgressBoardQueryHandler.cs
+++ b/MetaBond.Application/Feature/ProgressBoard/Query/GetCount/GetCountProgressBoardQueryHandler.cs
@@ -15,7 +15,7 @@ internal sealed class GetCountProgressBoardQueryHandler(
         GetCountProgressBoardQuery request,
         CancellationToken cancellationToken)
     {
-        var progressBoardCount =await progressBoardRepository.CountBoardsAsync(cancellationToken);
+        var progressBoardCount = await progressBoardRepository.CountBoardsAsync(cancellationToken);
 
         if (progressBoardCount == 0)
         {

--- a/MetaBond.Application/Feature/ProgressBoard/Query/GetProgressEntries/GetProgressBoardIdWithEntriesQueryHandler.cs
+++ b/MetaBond.Application/Feature/ProgressBoard/Query/GetProgressEntries/GetProgressBoardIdWithEntriesQueryHandler.cs
@@ -1,5 +1,6 @@
 ﻿using MetaBond.Application.Abstractions.Messaging;
 using MetaBond.Application.DTOs.ProgressBoard;
+using MetaBond.Application.Helpers;
 using MetaBond.Application.Interfaces.Repository;
 using MetaBond.Application.Mapper;
 using MetaBond.Application.Utils;
@@ -19,25 +20,24 @@ internal sealed class GetProgressBoardIdWithEntriesQueryHandler(
         GetProgressBoardIdWithEntriesQuery request,
         CancellationToken cancellationToken)
     {
-        if (request.PageNumber <= 0 || request.PageSize <= 0)
-        {
-            logger.LogWarning("Invalid pagination parameters: Page = {Page}, PageSize = {PageSize}", request.PageNumber,
-                request.PageSize);
+        var paginationValidationResult = PaginationHelper.ValidatePagination<ProgressBoardWithProgressEntryDTos>(
+            request.PageNumber,
+            request.PageSize,
+            logger
+        );
 
-            return ResultT<IEnumerable<ProgressBoardWithProgressEntryDTos>>.Failure(
-                Error.Failure("400",
-                    "Page number and page size must be greater than zero. Please provide valid pagination values."));
-        }
+        if (!paginationValidationResult.IsSuccess)
+            return paginationValidationResult.Error!;
 
-        var progressBoard = await repository.GetByIdAsync(request.ProgressBoardId);
-        if (progressBoard is null)
-        {
-            logger.LogError("No progress board found for ProgressBoardId: {ProgressBoardId}",
-                request.ProgressBoardId);
+        var progressBoard = await EntityHelper.GetEntityByIdAsync(
+            repository.GetByIdAsync,
+            request.ProgressBoardId,
+            "ProgressBoard",
+            logger
+        );
 
-            return ResultT<IEnumerable<ProgressBoardWithProgressEntryDTos>>.Failure(Error.NotFound("404",
-                "No progress board found for the given id"));
-        }
+        if (!progressBoard.IsSuccess)
+            return progressBoard.Error!;
 
         var progressBoardList = await repository.GetBoardsWithEntriesAsync(request.ProgressBoardId, cancellationToken);
 

--- a/MetaBond.Application/Feature/ProgressBoard/Query/GetRange/GetRangeProgressBoardQueryHandler.cs
+++ b/MetaBond.Application/Feature/ProgressBoard/Query/GetRange/GetRangeProgressBoardQueryHandler.cs
@@ -1,5 +1,6 @@
 ﻿using MetaBond.Application.Abstractions.Messaging;
 using MetaBond.Application.DTOs.ProgressBoard;
+using MetaBond.Application.Helpers;
 using MetaBond.Application.Interfaces.Repository;
 using MetaBond.Application.Mapper;
 using MetaBond.Application.Utils;
@@ -20,6 +21,16 @@ internal sealed class GetRangeProgressBoardQueryHandler(
         GetRangeProgressBoardQuery request,
         CancellationToken cancellationToken)
     {
+        var paginationValidationResult = PaginationHelper.ValidatePagination<ProgressBoardWithProgressEntryDTos>
+        (
+            request.Page,
+            request.PageSize,
+            logger
+        );
+        
+        if (!paginationValidationResult.IsSuccess)
+            return paginationValidationResult.Error!;
+
         var progressBoard = GetValue();
         if (progressBoard.TryGetValue((request.DateRangeType), out var progressBoardValue))
         {

--- a/MetaBond.Application/Feature/ProgressBoard/Query/Pagination/GetPagedProgressBoardQueryHandler.cs
+++ b/MetaBond.Application/Feature/ProgressBoard/Query/Pagination/GetPagedProgressBoardQueryHandler.cs
@@ -1,5 +1,6 @@
 ﻿using MetaBond.Application.Abstractions.Messaging;
 using MetaBond.Application.DTOs.ProgressBoard;
+using MetaBond.Application.Helpers;
 using MetaBond.Application.Interfaces.Repository;
 using MetaBond.Application.Mapper;
 using MetaBond.Application.Pagination;
@@ -19,6 +20,16 @@ internal sealed class GetPagedProgressBoardQueryHandler(
         GetPagedProgressBoardQuery request,
         CancellationToken cancellationToken)
     {
+        var validationPagination = PaginationHelper.ValidatePagination<ProgressBoardDTos>
+        (
+            request.PageNumber,
+            request.PageSize,
+            logger
+        );
+
+        if (!validationPagination.IsSuccess)
+            return validationPagination.Error!;
+
         string cacheKey = $"get-progress-board-paged-{request.PageNumber}-{request.PageSize}";
         var pageProgressBoard = await decoratedCache.GetOrCreateAsync(
             cacheKey,

--- a/MetaBond.Application/Feature/ProgressEntry/Commands/Delete/DeleteProgressEntryCommandHandler.cs
+++ b/MetaBond.Application/Feature/ProgressEntry/Commands/Delete/DeleteProgressEntryCommandHandler.cs
@@ -1,4 +1,5 @@
 ﻿using MetaBond.Application.Abstractions.Messaging;
+using MetaBond.Application.Helpers;
 using MetaBond.Application.Interfaces.Repository;
 using MetaBond.Application.Utils;
 using Microsoft.Extensions.Logging;
@@ -14,10 +15,18 @@ internal sealed class DeleteProgressEntryCommandHandler(
         DeleteProgressEntryCommand request,
         CancellationToken cancellationToken)
     {
-        var progressEntry = await repository.GetByIdAsync(request.Id);
-        if (progressEntry != null)
+        var progressEntry = await EntityHelper.GetEntityByIdAsync
+        (
+            repository.GetByIdAsync,
+            request.Id,
+            "ProgressEntry",
+            logger
+        );
+
+        if (progressEntry.IsSuccess)
         {
-            await repository.DeleteAsync(progressEntry, cancellationToken);
+            await repository.DeleteAsync(progressEntry.Value, cancellationToken);
+
             logger.LogInformation("Progress entry with ID {Id} successfully deleted.", request.Id);
 
             return ResultT<Guid>.Success(request.Id);

--- a/MetaBond.Application/Feature/ProgressEntry/Commands/Update/UpdateProgressEntryCommandHandler.cs
+++ b/MetaBond.Application/Feature/ProgressEntry/Commands/Update/UpdateProgressEntryCommandHandler.cs
@@ -1,5 +1,6 @@
 ﻿using MetaBond.Application.Abstractions.Messaging;
 using MetaBond.Application.DTOs.ProgressEntry;
+using MetaBond.Application.Helpers;
 using MetaBond.Application.Interfaces.Repository;
 using MetaBond.Application.Mapper;
 using MetaBond.Application.Utils;
@@ -13,20 +14,26 @@ internal sealed class UpdateProgressEntryCommandHandler(
     : ICommandHandler<UpdateProgressEntryCommand, ProgressEntryDTos>
 {
     public async Task<ResultT<ProgressEntryDTos>> Handle(
-        UpdateProgressEntryCommand request, 
+        UpdateProgressEntryCommand request,
         CancellationToken cancellationToken)
     {
-        var progressEntry = await progressEntryRepository.GetByIdAsync(request.ProgressEntryId);
-        if (progressEntry != null)
+        var progressEntry = await EntityHelper.GetEntityByIdAsync
+        (
+            progressEntryRepository.GetByIdAsync,
+            request.ProgressEntryId,
+            "ProgressEntry",
+            logger
+        );
+        if (progressEntry.IsSuccess)
         {
-            progressEntry.Description = request.Description;
-            progressEntry.UpdateAt = DateTime.UtcNow;
+            progressEntry.Value.Description = request.Description;
+            progressEntry.Value.UpdateAt = DateTime.UtcNow;
 
-            await progressEntryRepository.UpdateAsync(progressEntry,cancellationToken);
-            
+            await progressEntryRepository.UpdateAsync(progressEntry.Value, cancellationToken);
+
             logger.LogInformation("Progress entry with ID {Id} successfully updated.", request.ProgressEntryId);
-            
-            var progressEntryDto = ProgressEntryMapper.ToDto(progressEntry);
+
+            var progressEntryDto = ProgressEntryMapper.ToDto(progressEntry.Value);
 
             logger.LogInformation("Returning updated progress entry data.");
 

--- a/MetaBond.Application/Feature/ProgressEntry/Query/GetById/GetByIdProgressEntryQueryHandler.cs
+++ b/MetaBond.Application/Feature/ProgressEntry/Query/GetById/GetByIdProgressEntryQueryHandler.cs
@@ -1,5 +1,6 @@
 ﻿using MetaBond.Application.Abstractions.Messaging;
 using MetaBond.Application.DTOs.ProgressEntry;
+using MetaBond.Application.Helpers;
 using MetaBond.Application.Interfaces.Repository;
 using MetaBond.Application.Mapper;
 using MetaBond.Application.Utils;
@@ -10,19 +11,24 @@ namespace MetaBond.Application.Feature.ProgressEntry.Query.GetById;
 
 internal sealed class GetByIdProgressEntryQueryHandler(
     IProgressEntryRepository progressEntryRepository,
-    IDistributedCache decoratedCache,
     ILogger<GetByIdProgressEntryQueryHandler> logger)
     : IQueryHandler<GetByIdProgressEntryQuery, ProgressEntryDTos>
 {
     public async Task<ResultT<ProgressEntryDTos>> Handle(GetByIdProgressEntryQuery request,
         CancellationToken cancellationToken)
     {
-        var progressEntry = await progressEntryRepository.GetByIdAsync(request.ProgressEntryId);
-        if (progressEntry != null)
+        var progressEntry = await EntityHelper.GetEntityByIdAsync
+        (
+            progressEntryRepository.GetByIdAsync,
+            request.ProgressEntryId,
+            "ProgressEntry",
+            logger
+        );
+        if (progressEntry.IsSuccess)
         {
-            var progressEntryDto = ProgressEntryMapper.ToDto(progressEntry);
+            var progressEntryDto = ProgressEntryMapper.ToDto(progressEntry.Value);
 
-            logger.LogInformation("Progress entry with ID {Id} retrieved successfully.", progressEntry.Id);
+            logger.LogInformation("Progress entry with ID {Id} retrieved successfully.", progressEntry.Value.Id);
 
             return ResultT<ProgressEntryDTos>.Success(progressEntryDto);
         }

--- a/MetaBond.Application/Feature/ProgressEntry/Query/GetByIdProgressEntryWithProgressBoard/GetProgressEntryWithBoardByIdQueryHandler.cs
+++ b/MetaBond.Application/Feature/ProgressEntry/Query/GetByIdProgressEntryWithProgressBoard/GetProgressEntryWithBoardByIdQueryHandler.cs
@@ -1,5 +1,6 @@
 using MetaBond.Application.Abstractions.Messaging;
 using MetaBond.Application.DTOs.ProgressEntry;
+using MetaBond.Application.Helpers;
 using MetaBond.Application.Interfaces.Repository;
 using MetaBond.Application.Mapper;
 using MetaBond.Application.Utils;
@@ -18,8 +19,14 @@ internal sealed class GetProgressEntryWithBoardByIdQueryHandler(
         GetProgressEntryWithBoardByIdQuery request,
         CancellationToken cancellationToken)
     {
-        var progressEntry = await repository.GetByIdAsync(request.ProgressEntryId);
-        if (progressEntry is null)
+        var progressEntry = await EntityHelper.GetEntityByIdAsync(
+            repository.GetByIdAsync,
+            request.ProgressEntryId,
+            "ProgressEntry",
+            logger
+        );
+
+        if (!progressEntry.IsSuccess)
         {
             logger.LogError("Progress entry with ID {ProgressEntryId} not found.", request.ProgressEntryId);
 

--- a/MetaBond.Application/Feature/ProgressEntry/Query/GetCountByBoard/GetCountByBoardIdQueryHandler.cs
+++ b/MetaBond.Application/Feature/ProgressEntry/Query/GetCountByBoard/GetCountByBoardIdQueryHandler.cs
@@ -1,4 +1,5 @@
 ﻿using MetaBond.Application.Abstractions.Messaging;
+using MetaBond.Application.Helpers;
 using MetaBond.Application.Interfaces.Repository;
 using MetaBond.Application.Utils;
 using Microsoft.Extensions.Caching.Distributed;
@@ -16,8 +17,13 @@ internal sealed class GetCountByBoardIdQueryHandler(
         GetCountByBoardIdQuery request,
         CancellationToken cancellationToken)
     {
-        var progressBoard = await progressBoardRepository.GetByIdAsync(request.ProgressBoardId);
-        if (progressBoard is null)
+        var progressBoard = await EntityHelper.GetEntityByIdAsync(
+            progressBoardRepository.GetByIdAsync,
+            request.ProgressBoardId,
+            "ProgressBoard",
+            logger
+        );
+        if (!progressBoard.IsSuccess)
         {
             logger.LogError($"No progress board found with id: {request.ProgressBoardId}");
 

--- a/MetaBond.Application/Feature/ProgressEntry/Query/GetDateRange/GetEntriesByDateRangeQueryHandler.cs
+++ b/MetaBond.Application/Feature/ProgressEntry/Query/GetDateRange/GetEntriesByDateRangeQueryHandler.cs
@@ -1,5 +1,6 @@
 ﻿using MetaBond.Application.Abstractions.Messaging;
 using MetaBond.Application.DTOs.ProgressEntry;
+using MetaBond.Application.Helpers;
 using MetaBond.Application.Interfaces.Repository;
 using MetaBond.Application.Mapper;
 using MetaBond.Application.Utils;
@@ -19,6 +20,16 @@ internal sealed class GetEntriesByDateRangeQueryHandler(
         GetEntriesByDateRangeQuery request,
         CancellationToken cancellationToken)
     {
+        var progressEntryResult = await EntityHelper.GetEntityByIdAsync(
+            progressEntryRepository.GetByIdAsync,
+            request.ProgressBoardId,
+            "ProgressEntry",
+            logger
+        );
+
+        if (!progressEntryResult.IsSuccess)
+            return progressEntryResult.Error!;
+
         var progressEntry = GetValue(request.ProgressBoardId);
         if (progressEntry.TryGetValue((request.Range), out var dateRange))
         {

--- a/MetaBond.Application/Feature/ProgressEntry/Query/GetProgressEntriesWithAuthor/GetProgressEntriesWithAuthorsQueryHandler.cs
+++ b/MetaBond.Application/Feature/ProgressEntry/Query/GetProgressEntriesWithAuthor/GetProgressEntriesWithAuthorsQueryHandler.cs
@@ -1,6 +1,7 @@
 using MetaBond.Application.Abstractions.Messaging;
 using MetaBond.Application.DTOs.Account.User;
 using MetaBond.Application.DTOs.ProgressEntry;
+using MetaBond.Application.Helpers;
 using MetaBond.Application.Interfaces.Repository;
 using MetaBond.Application.Mapper;
 using MetaBond.Application.Utils;
@@ -19,14 +20,15 @@ public class GetProgressEntriesWithAuthorsQueryHandler(
     public async Task<ResultT<IEnumerable<ProgressEntriesWithUserDTos>>> Handle(
         GetProgressEntriesWithAuthorsQuery request, CancellationToken cancellationToken)
     {
-        var progressEntryId = await progressEntryRepository.GetByIdAsync(request.ProgressEntryId);
-        if (progressEntryId == null)
-        {
-            logger.LogError($"ProgressEntry with id {request.ProgressEntryId} not found");
-
-            return ResultT<IEnumerable<ProgressEntriesWithUserDTos>>.Failure(Error.NotFound("404",
-                "Progress entry not found"));
-        }
+        var progressEntry = await EntityHelper.GetEntityByIdAsync
+        (
+            progressEntryRepository.GetByIdAsync,
+            request.ProgressEntryId,
+            "ProgressEntry",
+            logger
+        );
+        if (!progressEntry.IsSuccess)
+            return progressEntry.Error!;
 
         var result = await decorated.GetOrCreateAsync(
             $"Get-Progress-Entries-With-Authors-{request.ProgressEntryId}",

--- a/MetaBond.Application/Feature/ProgressEntry/Query/GetRecent/GetRecentEntriesQueryHandler.cs
+++ b/MetaBond.Application/Feature/ProgressEntry/Query/GetRecent/GetRecentEntriesQueryHandler.cs
@@ -1,5 +1,6 @@
 ﻿using MetaBond.Application.Abstractions.Messaging;
 using MetaBond.Application.DTOs.ProgressEntry;
+using MetaBond.Application.Helpers;
 using MetaBond.Application.Interfaces.Repository;
 using MetaBond.Application.Mapper;
 using MetaBond.Application.Utils;
@@ -10,6 +11,7 @@ namespace MetaBond.Application.Feature.ProgressEntry.Query.GetRecent;
 
 internal sealed class GetRecentEntriesQueryHandler(
     IProgressEntryRepository repository,
+    IProgressBoardRepository progressBoardRepository,
     IDistributedCache decoratedCache,
     ILogger<GetRecentEntriesQueryHandler> logger)
     : IQueryHandler<GetRecentEntriesQuery, IEnumerable<ProgressEntryDTos>>
@@ -18,6 +20,16 @@ internal sealed class GetRecentEntriesQueryHandler(
         GetRecentEntriesQuery request,
         CancellationToken cancellationToken)
     {
+        var progressBoard = await EntityHelper.GetEntityByIdAsync(
+            progressBoardRepository.GetByIdAsync,
+            request.ProgressBoardId,
+            "ProgressBoard",
+            logger
+        );
+
+        if (!progressBoard.IsSuccess)
+            return progressBoard.Error!;
+
         if (request.TopCount <= 0)
         {
             logger.LogInformation("Invalid request: TopCount must be greater than zero.");

--- a/MetaBond.Application/Feature/Rewards/Commands/Delete/DeleteRewardsCommandHandler.cs
+++ b/MetaBond.Application/Feature/Rewards/Commands/Delete/DeleteRewardsCommandHandler.cs
@@ -1,4 +1,5 @@
 ﻿using MetaBond.Application.Abstractions.Messaging;
+using MetaBond.Application.Helpers;
 using MetaBond.Application.Interfaces.Repository;
 using MetaBond.Application.Utils;
 using Microsoft.Extensions.Logging;
@@ -14,14 +15,20 @@ internal sealed class DeleteRewardsCommandHandler(
         DeleteRewardsCommand request,
         CancellationToken cancellationToken)
     {
-        var reward = await repository.GetByIdAsync(request.RewardsId);
-        if (reward != null)
+        var reward = await EntityHelper.GetEntityByIdAsync(
+            repository.GetByIdAsync,
+            request.RewardsId,
+            "Rewards",
+            logger
+        );
+
+        if (reward.IsSuccess)
         {
-            await repository.DeleteAsync(reward, cancellationToken);
+            await repository.DeleteAsync(reward.Value, cancellationToken);
 
-            logger.LogInformation("Reward with ID {RewardsId} deleted successfully", reward.Id);
+            logger.LogInformation("Reward with ID {RewardsId} deleted successfully", reward.Value.Id);
 
-            return ResultT<Guid>.Success(reward.Id);
+            return ResultT<Guid>.Success(reward.Value.Id);
         }
 
         logger.LogError("Reward with ID {RewardsId} not found", request.RewardsId);

--- a/MetaBond.Application/Feature/Rewards/Commands/Update/UpdateRewardsCommandHandler.cs
+++ b/MetaBond.Application/Feature/Rewards/Commands/Update/UpdateRewardsCommandHandler.cs
@@ -1,5 +1,6 @@
 ﻿using MetaBond.Application.Abstractions.Messaging;
 using MetaBond.Application.DTOs.Rewards;
+using MetaBond.Application.Helpers;
 using MetaBond.Application.Interfaces.Repository;
 using MetaBond.Application.Mapper;
 using MetaBond.Application.Utils;
@@ -16,18 +17,23 @@ internal sealed class UpdateRewardsCommandHandler(
         UpdateRewardsCommand request,
         CancellationToken cancellationToken)
     {
-        var reward = await rewardsRepository.GetByIdAsync(request.RewardsId);
-        if (reward != null)
+        var reward = await EntityHelper.GetEntityByIdAsync(
+            rewardsRepository.GetByIdAsync,
+            request.RewardsId,
+            "Rewards",
+            logger
+        );
+        if (reward.IsSuccess)
         {
-            reward.Description = request.Description;
+            reward.Value.Description = request.Description;
 
-            reward.PointAwarded = request.PointAwarded;
+            reward.Value.PointAwarded = request.PointAwarded;
 
-            await rewardsRepository.UpdateAsync(reward, cancellationToken);
+            await rewardsRepository.UpdateAsync(reward.Value, cancellationToken);
 
             logger.LogInformation("Reward with ID: {RewardsId} updated successfully.", request.RewardsId);
 
-            var rewardsDTos = RewardsMapper.ToDto(reward);
+            var rewardsDTos = RewardsMapper.ToDto(reward.Value);
 
             return ResultT<RewardsDTos>.Success(rewardsDTos);
         }

--- a/MetaBond.Application/Feature/Rewards/Query/GetById/GetByIdRewardsQueryHandler.cs
+++ b/MetaBond.Application/Feature/Rewards/Query/GetById/GetByIdRewardsQueryHandler.cs
@@ -1,5 +1,6 @@
 ﻿using MetaBond.Application.Abstractions.Messaging;
 using MetaBond.Application.DTOs.Rewards;
+using MetaBond.Application.Helpers;
 using MetaBond.Application.Interfaces.Repository;
 using MetaBond.Application.Mapper;
 using MetaBond.Application.Utils;
@@ -10,7 +11,6 @@ namespace MetaBond.Application.Feature.Rewards.Query.GetById;
 
 internal sealed class GetByIdRewardsQueryHandler(
     IRewardsRepository rewardsRepository,
-    IDistributedCache decoratedCache,
     ILogger<GetByIdRewardsQueryHandler> logger)
     : IQueryHandler<GetByIdRewardsQuery, RewardsDTos>
 {
@@ -18,11 +18,16 @@ internal sealed class GetByIdRewardsQueryHandler(
         GetByIdRewardsQuery request,
         CancellationToken cancellationToken)
     {
-        var reward = await rewardsRepository.GetByIdAsync(request.RewardsId);
+        var reward = await EntityHelper.GetEntityByIdAsync(
+            rewardsRepository.GetByIdAsync,
+            request.RewardsId,
+            "Rewards",
+            logger
+        );
 
-        if (reward != null)
+        if (reward.IsSuccess)
         {
-            var rewardsDTos = RewardsMapper.ToDto(reward);
+            var rewardsDTos = RewardsMapper.ToDto(reward.Value);
 
             logger.LogInformation("Reward with ID: {RewardsId} found.", request.RewardsId);
 

--- a/MetaBond.Application/Feature/Rewards/Query/GetCount/GetCountRewardsQuery.cs
+++ b/MetaBond.Application/Feature/Rewards/Query/GetCount/GetCountRewardsQuery.cs
@@ -1,9 +1,5 @@
-﻿
-using MetaBond.Application.Abstractions.Messaging;
+﻿using MetaBond.Application.Abstractions.Messaging;
 
 namespace MetaBond.Application.Feature.Rewards.Query.GetCount;
 
-public sealed class GetCountRewardsQuery : IQuery<int>
-{
-        
-}
+public sealed class GetCountRewardsQuery : IQuery<int>;

--- a/MetaBond.Application/Feature/Rewards/Query/GetRange/GetByDateRangeRewardQueryHandler.cs
+++ b/MetaBond.Application/Feature/Rewards/Query/GetRange/GetByDateRangeRewardQueryHandler.cs
@@ -19,6 +19,13 @@ internal sealed class GetByDateRangeRewardQueryHandler(
         GetByDateRangeRewardQuery request,
         CancellationToken cancellationToken)
     {
+        if (string.IsNullOrEmpty(request.Range.ToString()))
+        {
+            logger.LogError("Invalid date range: {Range}. No matching rewards found.", request.Range);
+
+            return ResultT<IEnumerable<RewardsDTos>>.Failure(Error.Failure("400", "Invalid date range"));
+        }
+
         var rewards = GetValue();
         if (rewards.TryGetValue((request.Range), out var dateRange))
         {

--- a/MetaBond.Application/Feature/Rewards/Query/GetTop/GetTopRewardsQueryHandler.cs
+++ b/MetaBond.Application/Feature/Rewards/Query/GetTop/GetTopRewardsQueryHandler.cs
@@ -18,6 +18,13 @@ internal sealed class GetTopRewardsQueryHandler(
         GetTopRewardsQuery request,
         CancellationToken cancellationToken)
     {
+        if (request.TopCount <= 0)
+        {
+            logger.LogError("Invalid top count: {TopCount}.", request.TopCount);
+
+            return ResultT<IEnumerable<RewardsWithUserDTos>>.Failure(Error.Failure("400", "Invalid top count"));
+        }
+
         var result = await decoratedCache.GetOrCreateAsync(
             $"rewards-get-top-by-points-{request.TopCount}",
             async () =>

--- a/MetaBond.Application/Feature/User/Commands/ForgotPassword/ForgotPasswordUserCommandHandler.cs
+++ b/MetaBond.Application/Feature/User/Commands/ForgotPassword/ForgotPasswordUserCommandHandler.cs
@@ -19,31 +19,24 @@ internal sealed class ForgotPasswordUserCommandHandler(
         ForgotPasswordUserCommand request,
         CancellationToken cancellationToken)
     {
-        if (request != null)
+        var user = await userRepository.GetByEmailAsync(request!.Email!, cancellationToken);
+        if (user == null)
         {
-            var user = await userRepository.GetByEmailAsync(request!.Email!, cancellationToken);
-            if (user == null)
-            {
-                logger.LogError("Email {Email} not found during forgot password request", request.Email);
+            logger.LogError("Email {Email} not found during forgot password request", request.Email);
 
-                return ResultT<string>.Failure(Error.NotFound("404", $"No user found with email {request.Email}"));
-            }
-
-            var code = await emailConfirmationTokenService.GenerateTokenAsync(user.Id, cancellationToken);
-
-            await emailService.SendEmailAsync(new EmailRequestDTo(
-                To: user.Email,
-                Body: EmailTemplates.GetPasswordRecoveryEmailHtml(user.Username!, code.Value),
-                Subject: "Forgot Password"
-            ));
-
-            logger.LogInformation("Password reset code generated and email sent to {Email}", user.Email);
-
-            return ResultT<string>.Success("Password reset email sent successfully.");
+            return ResultT<string>.Failure(Error.NotFound("404", $"No user found with email {request.Email}"));
         }
 
-        logger.LogWarning("Forgot password request is null");
+        var code = await emailConfirmationTokenService.GenerateTokenAsync(user.Id, cancellationToken);
 
-        return ResultT<string>.Failure(Error.Failure("400", "Request cannot be null"));
+        await emailService.SendEmailAsync(new EmailRequestDTo(
+            To: user.Email,
+            Body: EmailTemplates.GetPasswordRecoveryEmailHtml(user.Username!, code.Value),
+            Subject: "Forgot Password"
+        ));
+
+        logger.LogInformation("Password reset code generated and email sent to {Email}", user.Email);
+
+        return ResultT<string>.Success("Password reset email sent successfully.");
     }
 }

--- a/MetaBond.Application/Feature/User/Commands/Update/UpdateUserCommandHandler.cs
+++ b/MetaBond.Application/Feature/User/Commands/Update/UpdateUserCommandHandler.cs
@@ -1,5 +1,6 @@
 using MetaBond.Application.Abstractions.Messaging;
 using MetaBond.Application.DTOs.Account.User;
+using MetaBond.Application.Helpers;
 using MetaBond.Application.Interfaces.Repository.Account;
 using MetaBond.Application.Interfaces.Service;
 using MetaBond.Application.Utils;
@@ -12,55 +13,55 @@ internal sealed class UpdateUserCommandHandler(
     IUserRepository userRepository,
     ILogger<UpdateUserCommandHandler> logger,
     IDistributedCache decoratedCache
-    ) : ICommandHandler<UpdateUserCommand, UpdateUserDTos>
+) : ICommandHandler<UpdateUserCommand, UpdateUserDTos>
 {
     public async Task<ResultT<UpdateUserDTos>> Handle(
-        UpdateUserCommand request, 
+        UpdateUserCommand request,
         CancellationToken cancellationToken)
     {
-        
-        var user = await decoratedCache.GetOrCreateAsync(
-            $"update-user-{request.UserId}",
-            async () => await userRepository.GetByIdAsync(request.UserId),
-            cancellationToken: cancellationToken);
+        var user = await EntityHelper.GetEntityByIdAsync(
+            userRepository.GetByIdAsync,
+            request.UserId,
+            "User",
+            logger
+        );
 
-        if (user == null)
-        {
-            logger.LogWarning("User with ID {UserId} was not found during update request.", request.UserId);
-            
-            return ResultT<UpdateUserDTos>.Failure(Error.NotFound("404", "User not found"));
-        }
+        if (!user.IsSuccess)
+            return user.Error!;
 
         var isEmailInUse = await userRepository.IsEmailInUseAsync(request.Email!, request.UserId, cancellationToken);
         if (isEmailInUse)
         {
-            logger.LogWarning("Email '{Email}' is already in use by another user. Update aborted for User ID {UserId}.", 
+            logger.LogWarning("Email '{Email}' is already in use by another user. Update aborted for User ID {UserId}.",
                 request.Email, request.UserId);
-            
+
             return ResultT<UpdateUserDTos>.Failure(Error.Failure("400", "Email already in use"));
         }
 
-        var isUsernameInUse = await userRepository.IsUsernameInUseAsync(request.Username!, request.UserId, cancellationToken);
+        var isUsernameInUse =
+            await userRepository.IsUsernameInUseAsync(request.Username!, request.UserId, cancellationToken);
         if (isUsernameInUse)
         {
-            logger.LogWarning("Username '{Username}' is already in use by another user. Update aborted for User ID {UserId}.", 
+            logger.LogWarning(
+                "Username '{Username}' is already in use by another user. Update aborted for User ID {UserId}.",
                 request.Username, request.UserId);
-            
+
             return ResultT<UpdateUserDTos>.Failure(Error.Failure("400", "Username already in use"));
         }
 
-        user.Username = request.Username;
-        user.Email = request.Email;
+        user.Value.Username = request.Username;
+        user.Value.Email = request.Email;
 
-        await userRepository.UpdateAsync(user, cancellationToken);
+        await userRepository.UpdateAsync(user.Value, cancellationToken);
 
         UpdateUserDTos updateUserDTos = new(
-            UserId:user.Id, 
-            Email:user.Email!, 
-            Username:request.Username!);
-        
-        logger.LogInformation("User with ID {UserId} successfully updated. New username: {Username}, new email: {Email}.", 
-            user.Id, user.Username, user.Email);
+            UserId: user.Value.Id,
+            Email: user.Value.Email!,
+            Username: request.Username!);
+
+        logger.LogInformation(
+            "User with ID {UserId} successfully updated. New username: {Username}, new email: {Email}.",
+            user.Value.Id, user.Value.Username, user.Value.Email);
 
         return ResultT<UpdateUserDTos>.Success(updateUserDTos);
     }

--- a/MetaBond.Application/Feature/User/Commands/UpdatePassword/UpdatePasswordUserCommandHandler.cs
+++ b/MetaBond.Application/Feature/User/Commands/UpdatePassword/UpdatePasswordUserCommandHandler.cs
@@ -16,36 +16,29 @@ internal sealed class UpdatePasswordUserCommandHandler(
         UpdatePasswordUserCommand request,
         CancellationToken cancellationToken)
     {
-        if (request != null)
+        var user = await userRepository.GetByEmailAsync(request.Email!, cancellationToken);
+        if (user == null)
         {
-            var user = await userRepository.GetByEmailAsync(request.Email!, cancellationToken);
-            if (user == null)
-            {
-                logger.LogWarning("User with email {RequestEmail} not found", request.Email);
+            logger.LogWarning("User with email {RequestEmail} not found", request.Email);
 
-                return ResultT<string>.Failure(Error.NotFound("404", $"No user found with email {request.Email}"));
-            }
-
-            var codeAvailabilityResult =
-                await emailConfirmationTokenService.IsCodeAvailableAsync(request.Code!, cancellationToken);
-            if (!codeAvailabilityResult.IsSuccess)
-            {
-                logger.LogWarning("Code '{Code}' has already been used.", request.Code);
-
-                return ResultT<string>.Failure(Error.Conflict("409", "The code has already been used."));
-            }
-
-            logger.LogInformation("Code '{Code}' is available.", request.Code);
-
-            var hashedPassword = BCrypt.Net.BCrypt.HashPassword(request.ConfirmNewPassword);
-
-            await userRepository.UpdatePasswordAsync(user, hashedPassword, cancellationToken);
-
-            return ResultT<string>.Success("Password has been successfully updated.");
+            return ResultT<string>.Failure(Error.NotFound("404", $"No user found with email {request.Email}"));
         }
 
-        logger.LogWarning("UpdatePasswordUserCommand: Request is null.");
+        var codeAvailabilityResult =
+            await emailConfirmationTokenService.IsCodeAvailableAsync(request.Code!, cancellationToken);
+        if (!codeAvailabilityResult.IsSuccess)
+        {
+            logger.LogWarning("Code '{Code}' has already been used.", request.Code);
 
-        return ResultT<string>.Failure(Error.Failure("400", "Invalid request"));
+            return ResultT<string>.Failure(Error.Conflict("409", "The code has already been used."));
+        }
+
+        logger.LogInformation("Code '{Code}' is available.", request.Code);
+
+        var hashedPassword = BCrypt.Net.BCrypt.HashPassword(request.ConfirmNewPassword);
+
+        await userRepository.UpdatePasswordAsync(user, hashedPassword, cancellationToken);
+
+        return ResultT<string>.Success("Password has been successfully updated.");
     }
 }

--- a/MetaBond.Application/Feature/User/Query/GetUserWithFriendship/GetUserWithFriendshipByIdQueryHandler.cs
+++ b/MetaBond.Application/Feature/User/Query/GetUserWithFriendship/GetUserWithFriendshipByIdQueryHandler.cs
@@ -1,6 +1,7 @@
 using MetaBond.Application.Abstractions.Messaging;
 using MetaBond.Application.DTOs.Account.User;
 using MetaBond.Application.DTOs.Friendship;
+using MetaBond.Application.Helpers;
 using MetaBond.Application.Interfaces.Repository.Account;
 using MetaBond.Application.Mapper;
 using MetaBond.Application.Utils;
@@ -20,13 +21,15 @@ internal sealed class GetUserWithFriendshipByIdQueryHandler(
         GetUserWithFriendshipByIdQuery request,
         CancellationToken cancellationToken)
     {
-        var user = await userRepository.GetByIdAsync(request.UserId ?? Guid.Empty);
-        if (user is null)
-        {
-            logger.LogError("User with ID: {UserId} not found.", request.UserId);
+        var user = await EntityHelper.GetEntityByIdAsync(
+            userRepository.GetByIdAsync,
+            request.UserId ?? Guid.Empty,
+            "User",
+            logger
+        );
 
-            return ResultT<UserWithFriendshipDTos>.Failure(Error.NotFound("404", "User not found."));
-        }
+        if (!user.IsSuccess)
+            return user.Error!;
 
         var userWithFriendship = await userRepository.GetUserWithFriendshipsAsync(request.UserId ?? Guid.Empty,
             cancellationToken);

--- a/MetaBond.Application/Feature/User/Query/SearchByUsername/SearchByUsernameUserQueryHandler.cs
+++ b/MetaBond.Application/Feature/User/Query/SearchByUsername/SearchByUsernameUserQueryHandler.cs
@@ -19,6 +19,14 @@ internal sealed class SearchByUsernameUserQueryHandler(
         SearchByUsernameUserQuery request,
         CancellationToken cancellationToken)
     {
+        if (string.IsNullOrWhiteSpace(request.Username))
+        {
+            logger.LogWarning("Username is required but was null or empty.");
+
+            return ResultT<IEnumerable<UserDTos>>.Failure(
+                Error.Failure("400", "The username cannot be null or empty."));
+        }
+
         var result = await decoratedCache.GetOrCreateAsync(
             $"search-username-{request.Username}",
             async () =>

--- a/MetaBond.Application/Helpers/PaginationHelper.cs
+++ b/MetaBond.Application/Helpers/PaginationHelper.cs
@@ -3,6 +3,7 @@ using MetaBond.Application.Utils;
 using Microsoft.Extensions.Logging;
 
 namespace MetaBond.Application.Helpers;
+
 public static class PaginationHelper
 {
     public static ResultT<PagedResult<T>> ValidatePagination<T>(int pageNumber, int pageSize, ILogger logger)
@@ -17,6 +18,6 @@ public static class PaginationHelper
                     "Invalid pagination parameters. PageNumber and PageSize must be greater than zero."));
         }
 
-        return null; // Indicates that it is valid
+        return ResultT<PagedResult<T>>.Success(null); // Indicates that it is valid
     }
 }


### PR DESCRIPTION

##  Description
This PR introduces two main refactors across multiple modules:
1. **Pagination validation helper** → Centralized logic to validate pagination parameters (`pageNumber`, `pageSize`) ensuring consistency across the codebase.  
2. **Reusable entity fetch by ID helper** → Created a generic helper to simplify fetching entities by ID and reduce duplicate code.  

These changes were applied to several modules for better maintainability and consistency.

## Changes
- Added `PaginationValidationHelper` to validate pagination parameters.
- Added `EntityByIdHelper` for fetching entities by ID.
- Refactored the following modules to use these helpers:
  - `CommunityMembership`
  - `Events`
  - `Friendship`
  - `Interest`
  - `ParticipationInEvent`
  - `Posts`
  - `ProgressBoard`
  - `ProgressEntry`
  - `Rewards`
  - `User`
