### PR TITLE
Refactor add community pagination

### DIFF
--- a/MetaBond.Application/Feature/Communities/Query/GetPostsAndEvents/GetCommunityDetailsByIdQuery.cs
+++ b/MetaBond.Application/Feature/Communities/Query/GetPostsAndEvents/GetCommunityDetailsByIdQuery.cs
@@ -5,15 +5,15 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using MetaBond.Application.DTOs.Communities;
+using MetaBond.Application.Pagination;
 
 namespace MetaBond.Application.Feature.Communities.Query.GetPostsAndEvents;
 
-    public sealed class GetCommunityDetailsByIdQuery : IQuery<IEnumerable<PostsAndEventsDTos>>
-    {
-        public Guid Id { get; set; }
-        
-        public int PageNumber { get; set;}
-        
-        public int PageSize { get; set; }
-    }
+public sealed class GetCommunityDetailsByIdQuery : IQuery<PagedResult<PostsAndEventsDTos>>
+{
+    public Guid Id { get; set; }
 
+    public int PageNumber { get; set; }
+
+    public int PageSize { get; set; }
+}

--- a/MetaBond.Application/Interfaces/Repository/ICommunitiesRepository.cs
+++ b/MetaBond.Application/Interfaces/Repository/ICommunitiesRepository.cs
@@ -40,9 +40,12 @@ public interface ICommunitiesRepository : IGenericRepository<Communities>
     /// Retrieves posts and events associated with a specific community.
     /// </summary>
     /// <param name="communitieId">The ID of the community.</param>
+    /// <param name="pageNumber"></param>
+    /// <param name="pageSize"></param>
     /// <param name="cancellationToken">Cancellation token for the async operation.</param>
     /// <returns>A collection of communities including their posts and events.</returns>
-    Task<IEnumerable<Communities>> GetPostsAndEventsByCommunityIdAsync(Guid communitieId,
+    Task<PagedResult<Communities>> GetPostsAndEventsByCommunityIdAsync(Guid communitieId,
+        int pageNumber, int pageSize,
         CancellationToken cancellationToken);
 
     /// <summary>

--- a/MetaBond.Presentation.Api/Controllers/V1/CommunitiesController.cs
+++ b/MetaBond.Presentation.Api/Controllers/V1/CommunitiesController.cs
@@ -100,7 +100,7 @@ public class CommunitiesController(IMediator mediator) : ControllerBase
         Summary = "Get detailed community information",
         Description = "Retrieves detailed information about a community, including pagination for related data."
     )]
-    public async Task<ResultT<IEnumerable<PostsAndEventsDTos>>> GetCommunitiesDetailsAsync(
+    public async Task<ResultT<PagedResult<PostsAndEventsDTos>>> GetCommunitiesDetailsAsync(
         [FromRoute] Guid id,
         [FromQuery] int pageNumber,
         [FromQuery] int pageSize,

--- a/MetaBond.Presentation.Api/Filters/ResultTActionFilter.cs
+++ b/MetaBond.Presentation.Api/Filters/ResultTActionFilter.cs
@@ -37,7 +37,7 @@ public class ResultTActionFilter(ILogger<ResultTActionFilter> logger) : IAsyncAc
                     // Create standardized error response
                     var errorResponse = new
                     {
-                        // code = resultT.Error?.Code,
+                        code = resultT.Error?.Code,
                         description = resultT.Error?.Description
                     };
 

--- a/MetaBond.Tests/Communities/CommunitiesCommandHandlerTests.cs
+++ b/MetaBond.Tests/Communities/CommunitiesCommandHandlerTests.cs
@@ -190,12 +190,12 @@ public class CommunitiesCommandHandlerTests
     [Fact]
     public async Task GetCommunitiesDetails_Tests()
     {
-        //Arrange
+        // Arrange
         var id = Guid.NewGuid();
         int pageNumber = 1;
         int pageSize = 10;
 
-        IEnumerable<PostsAndEventsDTos> postsAndEventsDTos = new List<PostsAndEventsDTos>
+        var postsAndEventsDtos = new List<PostsAndEventsDTos>
         {
             new PostsAndEventsDTos(
                 CommunitiesId: id,
@@ -213,21 +213,32 @@ public class CommunitiesCommandHandlerTests
             )
         };
 
-        var expectedResult = ResultT<IEnumerable<PostsAndEventsDTos>>.Success(postsAndEventsDTos);
+        // Creamos un PagedResult correctamente
+        PagedResult<PostsAndEventsDTos> pagedResult = new()
+        {
+            TotalItems = postsAndEventsDtos.Count,
+            CurrentPage = pageNumber,
+            TotalPages = 1,
+            Items = postsAndEventsDtos
+        };
 
-        _mediatorMock.Setup(m => m.Send(It.Is<GetCommunityDetailsByIdQuery>(q =>
-                q.Id == id && q.PageNumber == pageNumber && q.PageSize == pageSize), It.IsAny<CancellationToken>()))
+        var expectedResult = ResultT<PagedResult<PostsAndEventsDTos>>.Success(pagedResult);
+
+        _mediatorMock.Setup(m => m.Send(
+                It.Is<GetCommunityDetailsByIdQuery>(q =>
+                    q.Id == id && q.PageNumber == pageNumber && q.PageSize == pageSize),
+                It.IsAny<CancellationToken>()))
             .ReturnsAsync(expectedResult);
 
         var controller = new CommunitiesController(_mediatorMock.Object);
 
-        //Act
+        // Act
         var result = await controller.GetCommunitiesDetailsAsync(id, pageNumber, pageSize, CancellationToken.None);
 
         // Assert
         Assert.NotNull(result);
         Assert.True(result.IsSuccess);
-        Assert.Equal(postsAndEventsDTos, result.Value);
+        Assert.Equal(pagedResult, result.Value);
     }
 
     [Fact]


### PR DESCRIPTION
## Description
This PR introduces refactorings and improvements related to the handling of communities, posts, and events in the controller and corresponding tests.

### Changes Included
- **Controller**
  - Refactored to use `PagedResult` when returning posts and events for a community.
  - Ensures proper pagination metadata (`TotalItems`, `PageSize`, `CurrentPage`, `TotalPages`) is returned.

- **Tests**
  - Updated unit tests to match the new `PagedResult` structure.
  - Ensures controller returns the correct paged data in all test scenarios.

- **Filtering**
  - Updated filter logic to improve clarity and maintainability.

## Notes
These changes improve consistency and maintainability of the communities endpoints, and ensure paginated responses are properly tested.
