### PR TITLE
Refactor add events pagination

### DIFF
--- a/MetaBond.Application/Feature/Events/Commands/Create/CreateEventsCommandHandler.cs
+++ b/MetaBond.Application/Feature/Events/Commands/Create/CreateEventsCommandHandler.cs
@@ -9,6 +9,7 @@ namespace MetaBond.Application.Feature.Events.Commands.Create
 {
     internal sealed class CreateEventsCommandHandler(
         IEventsRepository eventsRepository,
+        ICommunitiesRepository communitiesRepository,
         ILogger<CreateEventsCommandHandler> logger)
         : ICommandHandler<CreateEventsCommand, EventsDto>
     {
@@ -16,6 +17,16 @@ namespace MetaBond.Application.Feature.Events.Commands.Create
             CreateEventsCommand request,
             CancellationToken cancellationToken)
         {
+            var exists =
+                await communitiesRepository.ValidateAsync(x => x.Id == request.CommunitiesId, cancellationToken);
+            if (!exists)
+            {
+                logger.LogError("The community with ID {Id} does not exist.", request.CommunitiesId);
+
+                return ResultT<EventsDto>.Failure(Error.NotFound("404",
+                    $"{request.CommunitiesId} not found"));
+            }
+
             Domain.Models.Events events = new()
             {
                 Id = Guid.NewGuid(),

--- a/MetaBond.Application/Feature/Events/Commands/Delete/DeleteEventsCommandHandler.cs
+++ b/MetaBond.Application/Feature/Events/Commands/Delete/DeleteEventsCommandHandler.cs
@@ -21,18 +21,13 @@ namespace MetaBond.Application.Feature.Events.Commands.Delete
                 "Events",
                 logger);
 
-            if (events.IsSuccess)
-            {
-                await eventsRepository.DeleteAsync(events.Value, cancellationToken);
+            if (!events.IsSuccess) return events.Error!;
 
-                logger.LogInformation("Event with ID {EventId} was successfully deleted.", request.Id);
+            await eventsRepository.DeleteAsync(events.Value, cancellationToken);
 
-                return ResultT<Guid>.Success(request.Id);
-            }
+            logger.LogInformation("Event with ID {EventId} was successfully deleted.", request.Id);
 
-            logger.LogError("Failed to delete event. Event with ID {EventId} was not found.", request.Id);
-
-            return ResultT<Guid>.Failure(Error.NotFound("404", $"{request.Id} not found"));
+            return ResultT<Guid>.Success(request.Id);
         }
     }
 }

--- a/MetaBond.Application/Feature/Events/Commands/Update/UpdateEventsCommandHandler.cs
+++ b/MetaBond.Application/Feature/Events/Commands/Update/UpdateEventsCommandHandler.cs
@@ -22,23 +22,16 @@ internal sealed class UpdateEventsCommandHandler(
             "Events",
             logger);
 
-        if (!events.IsSuccess) return ResultT<EventsDto>.Failure(events.Error!);
+        if (!events.IsSuccess) return events.Error!;
 
-        if (events != null)
-        {
-            events.Value.Description = request.Description;
-            events.Value.Title = request.Title;
-            await eventsRepository.UpdateAsync(events.Value, cancellationToken);
+        events.Value.Description = request.Description;
+        events.Value.Title = request.Title;
+        await eventsRepository.UpdateAsync(events.Value, cancellationToken);
 
-            logger.LogInformation("Event with ID {EventId} was successfully updated.", request.Id);
+        logger.LogInformation("Event with ID {EventId} was successfully updated.", request.Id);
 
-            var eventsDto = EventsMapper.EventsToDto(events.Value);
+        var eventsDto = EventsMapper.EventsToDto(events.Value);
 
-            return ResultT<EventsDto>.Success(eventsDto);
-        }
-
-        logger.LogError("Failed to update event. Event with ID {EventId} was not found.", request.Id);
-
-        return ResultT<EventsDto>.Failure(Error.NotFound("404", $"{request.Id} not found"));
+        return ResultT<EventsDto>.Success(eventsDto);
     }
 }

--- a/MetaBond.Application/Feature/Events/Query/FilterByDateRange/FilterByDateRangeEventsQuery.cs
+++ b/MetaBond.Application/Feature/Events/Query/FilterByDateRange/FilterByDateRangeEventsQuery.cs
@@ -1,12 +1,16 @@
 ﻿using MetaBond.Application.Abstractions.Messaging;
 using MetaBond.Application.DTOs.Events;
+using MetaBond.Application.Pagination;
 using MetaBond.Domain;
 
-namespace MetaBond.Application.Feature.Events.Query.FilterByDateRange
+namespace MetaBond.Application.Feature.Events.Query.FilterByDateRange;
+
+public sealed class FilterByDateRangeEventsQuery : IQuery<PagedResult<EventsDto>>
 {
-    public sealed class FilterByDateRangeEventsQuery : IQuery<IEnumerable<EventsDto>>
-    {
-        public Guid CommunitiesId { get; set; }
-        public DateRangeFilter DateRangeFilter { get; set; }
-    }
+    public Guid CommunitiesId { get; set; }
+    public DateRangeFilter DateRangeFilter { get; set; }
+
+    public int PageNumber { get; set; }
+
+    public int PageSize { get; set; }
 }

--- a/MetaBond.Application/Feature/Events/Query/FilterByTitle/FilterByTitleEventsQuery.cs
+++ b/MetaBond.Application/Feature/Events/Query/FilterByTitle/FilterByTitleEventsQuery.cs
@@ -1,10 +1,14 @@
 ﻿using MetaBond.Application.Abstractions.Messaging;
 using MetaBond.Application.DTOs.Events;
+using MetaBond.Application.Pagination;
 
-namespace MetaBond.Application.Feature.Events.Query.FilterByTitle
+namespace MetaBond.Application.Feature.Events.Query.FilterByTitle;
+
+public sealed class FilterByTitleEventsQuery : IQuery<PagedResult<EventsDto>>
 {
-    public sealed class FilterByTitleEventsQuery : IQuery<IEnumerable<EventsDto>>
-    {
-        public string? Title { get; set; }
-    }
+    public string? Title { get; set; }
+
+    public int PageNumber { get; set; }
+
+    public int PageSize { get; set; }
 }

--- a/MetaBond.Application/Feature/Events/Query/FilterByTitleCommunityId/GetEventsByTitleAndCommunityIdQuery.cs
+++ b/MetaBond.Application/Feature/Events/Query/FilterByTitleCommunityId/GetEventsByTitleAndCommunityIdQuery.cs
@@ -1,11 +1,16 @@
 using MetaBond.Application.Abstractions.Messaging;
 using MetaBond.Application.DTOs.Events;
+using MetaBond.Application.Pagination;
 
 namespace MetaBond.Application.Feature.Events.Query.FilterByTitleCommunityId;
 
-public class GetEventsByTitleAndCommunityIdQuery : IQuery<IEnumerable<EventsDto>>
+public class GetEventsByTitleAndCommunityIdQuery : IQuery<PagedResult<EventsDto>>
 {
     public Guid CommunitiesId { get; set; }
-    
+
     public string? Title { get; set; }
+
+    public int PageNumber { get; set; }
+
+    public int PageSize { get; set; }
 }

--- a/MetaBond.Application/Feature/Events/Query/GetById/GetByIdEventsQuery.cs
+++ b/MetaBond.Application/Feature/Events/Query/GetById/GetByIdEventsQuery.cs
@@ -1,15 +1,9 @@
 ﻿using MetaBond.Application.Abstractions.Messaging;
 using MetaBond.Application.DTOs.Events;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
-namespace MetaBond.Application.Feature.Events.Query.GetById
+namespace MetaBond.Application.Feature.Events.Query.GetById;
+
+public sealed class GetByIdEventsQuery : IQuery<EventsDto>
 {
-    public sealed class GetByIdEventsQuery : IQuery<EventsDto>
-    {
-        public Guid Id { get; set; }
-    }
+    public Guid Id { get; set; }
 }

--- a/MetaBond.Application/Feature/Events/Query/GetById/GetByIdEventsQueryHandler.cs
+++ b/MetaBond.Application/Feature/Events/Query/GetById/GetByIdEventsQueryHandler.cs
@@ -26,12 +26,7 @@ internal sealed class GetByIdEventsQueryHandler(
             "Events",
             logger
         );
-        if (!events.IsSuccess)
-        {
-            logger.LogError("Events with ID {EventId} not found.", request.Id);
-
-            return ResultT<EventsDto>.Failure(events.Error!);
-        }
+        if (!events.IsSuccess) return events.Error;
 
         var eventsDto = EventsMapper.EventsToDto(events.Value);
 

--- a/MetaBond.Application/Feature/Events/Query/GetCommunities/GetEventsDetailsQuery.cs
+++ b/MetaBond.Application/Feature/Events/Query/GetCommunities/GetEventsDetailsQuery.cs
@@ -1,10 +1,14 @@
 ﻿using MetaBond.Application.Abstractions.Messaging;
 using MetaBond.Application.DTOs.Events;
+using MetaBond.Application.Pagination;
 
-namespace MetaBond.Application.Feature.Events.Query.GetCommunitiesAndParticipationInEvent
+namespace MetaBond.Application.Feature.Events.Query.GetCommunities;
+
+public sealed class GetEventsDetailsQuery : IQuery<PagedResult<CommunitiesEventsDTos>>
 {
-    public sealed class GetEventsDetailsQuery : IQuery<IEnumerable<CommunitiesEventsDTos>>
-    {
-        public Guid Id { get; set; }
-    }
+    public Guid Id { get; set; }
+
+    public int PageNumber { get; set; }
+
+    public int PageSize { get; set; }
 }

--- a/MetaBond.Application/Feature/Events/Query/GetEventsWithParticipationInEvent/GetEventsWithParticipationInEventQuery.cs
+++ b/MetaBond.Application/Feature/Events/Query/GetEventsWithParticipationInEvent/GetEventsWithParticipationInEventQuery.cs
@@ -1,11 +1,14 @@
-﻿
-using MetaBond.Application.Abstractions.Messaging;
+﻿using MetaBond.Application.Abstractions.Messaging;
 using MetaBond.Application.DTOs.Events;
+using MetaBond.Application.Pagination;
 
-namespace MetaBond.Application.Feature.Events.Query.GetEventsWithParticipationInEvent
+namespace MetaBond.Application.Feature.Events.Query.GetEventsWithParticipationInEvent;
+
+public sealed class GetEventsWithParticipationInEventQuery : IQuery<PagedResult<EventsWithParticipationInEventsDTos>>
 {
-    public sealed class GetEventsWithParticipationInEventQuery : IQuery<IEnumerable<EventsWithParticipationInEventsDTos>>
-    {
-        public Guid? EventsId { get; set; }
-    }
+    public Guid? EventsId { get; set; }
+
+    public int PageNumber { get; set; }
+
+    public int PageSize { get; set; }
 }

--- a/MetaBond.Application/Feature/Events/Query/GetOrderById/GetOrderByIdEventsQuery.cs
+++ b/MetaBond.Application/Feature/Events/Query/GetOrderById/GetOrderByIdEventsQuery.cs
@@ -1,10 +1,14 @@
 ﻿using MetaBond.Application.Abstractions.Messaging;
 using MetaBond.Application.DTOs.Events;
+using MetaBond.Application.Pagination;
 
-namespace MetaBond.Application.Feature.Events.Query.GetOrderById
+namespace MetaBond.Application.Feature.Events.Query.GetOrderById;
+
+public sealed class GetOrderByIdEventsQuery : IQuery<PagedResult<EventsDto>>
 {
-    public sealed class GetOrderByIdEventsQuery : IQuery<IEnumerable<EventsDto>>
-    {
-        public string? Order {  get; set; } 
-    }
+    public string? Order { get; set; }
+    
+    public int PageNumber { get; set; }
+    
+    public int PageSize { get; set; }
 }

--- a/MetaBond.Application/Feature/Events/Query/GetOrderById/GetOrderByIdEventsQueryHandler.cs
+++ b/MetaBond.Application/Feature/Events/Query/GetOrderById/GetOrderByIdEventsQueryHandler.cs
@@ -1,7 +1,9 @@
 ﻿using MetaBond.Application.Abstractions.Messaging;
 using MetaBond.Application.DTOs.Events;
+using MetaBond.Application.Helpers;
 using MetaBond.Application.Interfaces.Repository;
 using MetaBond.Application.Mapper;
+using MetaBond.Application.Pagination;
 using MetaBond.Application.Utils;
 using Microsoft.Extensions.Caching.Distributed;
 using Microsoft.Extensions.Logging;
@@ -12,56 +14,74 @@ internal sealed class GetOrderByIdEventsQueryHandler(
     IEventsRepository eventsRepository,
     IDistributedCache decoratedCache,
     ILogger<GetOrderByIdEventsQueryHandler> logger)
-    : IQueryHandler<GetOrderByIdEventsQuery, IEnumerable<EventsDto>>
+    : IQueryHandler<GetOrderByIdEventsQuery, PagedResult<EventsDto>>
 {
-    public async Task<ResultT<IEnumerable<EventsDto>>> Handle(GetOrderByIdEventsQuery request,
+    public async Task<ResultT<PagedResult<EventsDto>>> Handle(GetOrderByIdEventsQuery request,
         CancellationToken cancellationToken)
     {
-        var eventsSort = GetSortValues();
-        if (eventsSort.TryGetValue((request.Order!), out var getSort))
+        var paginationValidation = PaginationHelper.ValidatePagination<EventsDto>(request.PageNumber,
+            request.PageSize, logger);
+
+        if (!paginationValidation.IsSuccess) return paginationValidation;
+
+        var eventsSort = GetSortValues(request.PageNumber, request.PageSize);
+        if (eventsSort.TryGetValue((request.Order ?? string.Empty), out var getSort))
         {
             var eventsListSort = await decoratedCache.GetOrCreateAsync(
                 $"order-{request.Order}",
                 async () =>
                 {
                     var eventSort = await getSort(cancellationToken);
-                    IEnumerable<EventsDto> eventsDtos = eventSort.Select(EventsMapper.EventsToDto).ToList();
+                    IEnumerable<EventsDto> eventsDtos = eventSort.Items.Select(EventsMapper.EventsToDto).ToList();
 
-                    return eventsDtos;
+                    PagedResult<EventsDto> pagedResult = new(
+                        currentPage: eventSort.CurrentPage,
+                        items: eventsDtos,
+                        totalItems: eventSort.TotalItems,
+                        pageSize: request.PageSize
+                    );
+
+                    return pagedResult;
                 },
                 cancellationToken: cancellationToken);
 
-            var listSort = eventsListSort.ToList();
-            if (!listSort.Any())
+            if (!eventsListSort.Items.Any())
             {
                 logger.LogError("No events found for the specified order.");
 
-                return ResultT<IEnumerable<EventsDto>>.Failure(Error.Failure("400",
+                return ResultT<PagedResult<EventsDto>>.Failure(Error.Failure("400",
                     "No events found for the given order."));
             }
 
-            IEnumerable<EventsDto> value = listSort.ToList();
-            logger.LogInformation("Successfully retrieved {Count} events ordered by {Order}.", value.Count(),
+            logger.LogInformation("Successfully retrieved {Count} events ordered by {Order}.",
+                eventsListSort.Items.Count(),
                 request.Order);
 
-            return ResultT<IEnumerable<EventsDto>>.Success(value);
+            return ResultT<PagedResult<EventsDto>>.Success(eventsListSort);
         }
 
         logger.LogError("Invalid order parameter received: {Order}. Please specify 'asc' or 'desc'.",
             request.Order);
 
-        return ResultT<IEnumerable<EventsDto>>.Failure(Error.Failure("400",
+        return ResultT<PagedResult<EventsDto>>.Failure(Error.Failure("400",
             "Invalid order parameter. Please specify 'asc' or 'desc'."));
     }
 
     #region Private Methods
 
-    private Dictionary<string, Func<CancellationToken, Task<IEnumerable<Domain.Models.Events>>>> GetSortValues()
+    private Dictionary<string, Func<CancellationToken, Task<PagedResult<Domain.Models.Events>>>> GetSortValues(
+        int pageNumber, int pageSize)
     {
-        return new Dictionary<string, Func<CancellationToken, Task<IEnumerable<Domain.Models.Events>>>>
+        return new Dictionary<string, Func<CancellationToken, Task<PagedResult<Domain.Models.Events>>>>
         {
-            { "asc", async cancellationToken => await eventsRepository.GetOrderByIdAscAsync(cancellationToken) },
-            { "desc", async cancellationToken => await eventsRepository.GetOrderByIdDescAsync(cancellationToken) }
+            {
+                "asc", async cancellationToken => await eventsRepository.GetOrderByIdAscAsync(pageNumber, pageSize,
+                    cancellationToken)
+            },
+            {
+                "desc", async cancellationToken => await eventsRepository.GetOrderByIdDescAsync(pageNumber, pageSize,
+                    cancellationToken)
+            }
         };
     }
 

--- a/MetaBond.Application/Feature/Events/Query/Pagination/GetPagedEventsQuery.cs
+++ b/MetaBond.Application/Feature/Events/Query/Pagination/GetPagedEventsQuery.cs
@@ -1,18 +1,12 @@
 ﻿using MetaBond.Application.Abstractions.Messaging;
 using MetaBond.Application.DTOs.Events;
 using MetaBond.Application.Pagination;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
-namespace MetaBond.Application.Feature.Events.Query.Pagination
+namespace MetaBond.Application.Feature.Events.Query.Pagination;
+
+public sealed class GetPagedEventsQuery : IQuery<PagedResult<EventsDto>>
 {
-    public sealed class GetPagedEventsQuery : IQuery<PagedResult<EventsDto>>
-    {
-        public int PageNumber { get; set; }
+    public int PageNumber { get; set; }
 
-        public int PageSize { get; set; }
-    }
+    public int PageSize { get; set; }
 }

--- a/MetaBond.Application/Interfaces/Repository/IEventsRepository.cs
+++ b/MetaBond.Application/Interfaces/Repository/IEventsRepository.cs
@@ -12,65 +12,46 @@ public interface IEventsRepository : IGenericRepository<Events>
     /// <summary>
     /// Retrieves a paginated list of events.
     /// </summary>
-    /// <param name="pageNumber">The page number to retrieve.</param>
-    /// <param name="pageSize">The number of events per page.</param>
-    /// <param name="cancellationToken">Cancellation token for the async operation.</param>
-    /// <returns>A paginated result of events.</returns>
     Task<PagedResult<Events>> GetPagedEventsAsync(int pageNumber, int pageSize, CancellationToken cancellationToken);
 
     /// <summary>
-    /// Retrieves events that contain the specified title.
+    /// Retrieves events that contain the specified title with pagination.
     /// </summary>
-    /// <param name="title">The title or partial title to filter events.</param>
-    /// <param name="cancellationToken">Cancellation token for the async operation.</param>
-    /// <returns>A collection of events matching the title.</returns>
-    Task<IEnumerable<Events>> GetFilterByTitleAsync(string title, CancellationToken cancellationToken);
+    Task<PagedResult<Events>> GetFilterByTitleAsync(string title, int pageNumber, int pageSize,
+        CancellationToken cancellationToken);
 
     /// <summary>
-    /// Retrieves all events ordered by their ID in ascending order.
+    /// Retrieves all events ordered by their ID in ascending order with pagination.
     /// </summary>
-    /// <param name="cancellationToken">Cancellation token for the async operation.</param>
-    /// <returns>A collection of events ordered by ID ascending.</returns>
-    Task<IEnumerable<Events>> GetOrderByIdAscAsync(CancellationToken cancellationToken);
+    Task<PagedResult<Events>> GetOrderByIdAscAsync(int pageNumber, int pageSize, CancellationToken cancellationToken);
 
     /// <summary>
-    /// Retrieves all events ordered by their ID in descending order.
+    /// Retrieves all events ordered by their ID in descending order with pagination.
     /// </summary>
-    /// <param name="cancellationToken">Cancellation token for the async operation.</param>
-    /// <returns>A collection of events ordered by ID descending.</returns>
-    Task<IEnumerable<Events>> GetOrderByIdDescAsync(CancellationToken cancellationToken);
+    Task<PagedResult<Events>> GetOrderByIdDescAsync(int pageNumber, int pageSize, CancellationToken cancellationToken);
 
     /// <summary>
-    /// Filters events within a specific date range for a given community.
+    /// Filters events by a specific date for a given community with pagination.
     /// </summary>
-    /// <param name="communitiesId">The ID of the community.</param>
-    /// <param name="dateFilter">The date to use as a filter (e.g., start or specific day).</param>
-    /// <param name="cancellationToken">Cancellation token for the async operation.</param>
-    /// <returns>A collection of events within the date range for the community.</returns>
-    Task<IEnumerable<Events>> FilterByDateRange(Guid communitiesId, DateTime dateFilter, CancellationToken cancellationToken);
+    Task<PagedResult<Events>> FilterByDateRangeAsync(Guid communitiesId, DateTime dateFilter, int pageNumber,
+        int pageSize, CancellationToken cancellationToken);
 
     /// <summary>
-    /// Retrieves events related to a specific community.
+    /// Retrieves events associated with a specific community with pagination.
     /// </summary>
-    /// <param name="id">The ID of the community.</param>
-    /// <param name="cancellationToken">Cancellation token for the async operation.</param>
-    /// <returns>A collection of events associated with the given community.</returns>
-    Task<IEnumerable<Events>> GetCommunities(Guid id, CancellationToken cancellationToken);
+    Task<PagedResult<Events>> GetCommunitiesAsync(Guid id, int pageNumber, int pageSize,
+        CancellationToken cancellationToken);
 
     /// <summary>
-    /// Retrieves an event along with its participations.
+    /// Retrieves an event along with its participations with pagination.
     /// </summary>
-    /// <param name="eventId">The ID of the event.</param>
-    /// <param name="cancellationToken">Cancellation token for the async operation.</param>
-    /// <returns>A collection of events including participation data.</returns>
-    Task<IEnumerable<Events>> GetEventsWithParticipationAsync(Guid eventId, CancellationToken cancellationToken);
+    Task<PagedResult<Events>> GetEventsWithParticipationAsync(Guid eventId, int pageNumber, int pageSize,
+        CancellationToken cancellationToken);
 
     /// <summary>
     /// Retrieves events that match a specific title and belong to a given community.
     /// </summary>
-    /// <param name="communitiesId">The ID of the community.</param>
-    /// <param name="title">The title or partial title to filter events.</param>
-    /// <param name="cancellationToken">Cancellation token for the async operation.</param>
-    /// <returns>A collection of events that match the title and community ID.</returns>
-    Task<IEnumerable<Events>> GetEventsByTitleAndCommunityIdAsync(Guid communitiesId, string title, CancellationToken cancellationToken);
+    Task<PagedResult<Events>> GetEventsByTitleAndCommunityIdAsync(Guid communitiesId, string title,
+        int pageNumber, int pageSize,
+        CancellationToken cancellationToken);
 }

--- a/MetaBond.Application/Mapper/CommunityMapper.cs
+++ b/MetaBond.Application/Mapper/CommunityMapper.cs
@@ -43,7 +43,7 @@ public static class CommunityMapper
         );
     }
 
-    public static IEnumerable<CommunitiesEventsDTos> ToCommunitiesDtos(this IEnumerable<Events> events)
+    public static IEnumerable<CommunitiesEventsDTos> ToCommunitiesDtos(this IEnumerable<Events>? events)
     {
         return events.Select(e => new CommunitiesEventsDTos(
             Id: e.Id,

--- a/MetaBond.Presentation.Api/Controllers/V1/EventsController.cs
+++ b/MetaBond.Presentation.Api/Controllers/V1/EventsController.cs
@@ -8,7 +8,7 @@ using MetaBond.Application.Feature.Events.Query.FilterByDateRange;
 using MetaBond.Application.Feature.Events.Query.FilterByTitle;
 using MetaBond.Application.Feature.Events.Query.FilterByTitleCommunityId;
 using MetaBond.Application.Feature.Events.Query.GetById;
-using MetaBond.Application.Feature.Events.Query.GetCommunitiesAndParticipationInEvent;
+using MetaBond.Application.Feature.Events.Query.GetCommunities;
 using MetaBond.Application.Feature.Events.Query.GetEventsWithParticipationInEvent;
 using MetaBond.Application.Feature.Events.Query.GetOrderById;
 using MetaBond.Application.Feature.Events.Query.Pagination;
@@ -83,15 +83,19 @@ public class EventsController(IMediator mediator) : ControllerBase
         Summary = "Filter events by date range for a community",
         Description = "Retrieves events for a specific community that fall within the specified date range."
     )]
-    public async Task<ResultT<IEnumerable<EventsDto>>> FilterByRangeAsync(
+    public async Task<ResultT<PagedResult<EventsDto>>> FilterByRangeAsync(
         [FromRoute] Guid communitiesId,
         [FromQuery] DateRangeFilter dateRange,
+        [FromQuery] int pageNumber,
+        [FromQuery] int pageSize,
         CancellationToken cancellationToken)
     {
         var query = new FilterByDateRangeEventsQuery
         {
             CommunitiesId = communitiesId,
-            DateRangeFilter = dateRange
+            DateRangeFilter = dateRange,
+            PageNumber = pageNumber,
+            PageSize = pageSize,
         };
 
         return await mediator.Send(query, cancellationToken);
@@ -103,15 +107,19 @@ public class EventsController(IMediator mediator) : ControllerBase
         Summary = "Filter events by title",
         Description = "Retrieves all events matching the specified title."
     )]
-    public async Task<IActionResult> FilterByTitleAsync([FromRoute] string title, CancellationToken cancellationToken)
+    public async Task<ResultT<PagedResult<EventsDto>>> FilterByTitleAsync([FromRoute] string title,
+        [FromQuery] int pageNumber,
+        [FromQuery] int pageSize,
+        CancellationToken cancellationToken)
     {
-        var query = new FilterByTitleEventsQuery { Title = title };
+        var query = new FilterByTitleEventsQuery
+        {
+            Title = title,
+            PageNumber = pageNumber,
+            PageSize = pageSize
+        };
 
-        var result = await mediator.Send(query, cancellationToken);
-
-        return !result.IsSuccess
-            ? StatusCode(result.Error!.Code.ToInt(), result.Error)
-            : Ok(result.Value);
+        return await mediator.Send(query, cancellationToken);
     }
 
     [HttpGet("communities/{communityId}/search/title/{title}")]
@@ -120,15 +128,19 @@ public class EventsController(IMediator mediator) : ControllerBase
         Summary = "Get events by title and community",
         Description = "Retrieves events with the specified title within a specific community."
     )]
-    public async Task<ResultT<IEnumerable<EventsDto>>> GetEventsByTitleAndCommunityIdAsync(
+    public async Task<ResultT<PagedResult<EventsDto>>> GetEventsByTitleAndCommunityIdAsync(
         [FromRoute] Guid communityId,
         [FromRoute] string title,
+        [FromQuery] int pageNumber,
+        [FromQuery] int pageSize,
         CancellationToken cancellationToken)
     {
         var query = new GetEventsByTitleAndCommunityIdQuery
         {
             CommunitiesId = communityId,
-            Title = title
+            Title = title,
+            PageNumber = pageNumber,
+            PageSize = pageSize
         };
 
         return await mediator.Send(query, cancellationToken);
@@ -140,11 +152,18 @@ public class EventsController(IMediator mediator) : ControllerBase
         Summary = "Get event with communities",
         Description = "Retrieves the details of an event including the communities it belongs to."
     )]
-    public async Task<ResultT<IEnumerable<CommunitiesEventsDTos>>> GetEventsWithCommunitiesAsync(
+    public async Task<ResultT<PagedResult<CommunitiesEventsDTos>>> GetEventsWithCommunitiesAsync(
         [FromRoute] Guid eventId,
+        [FromQuery] int pageNumber,
+        [FromQuery] int pageSize,
         CancellationToken cancellationToken)
     {
-        var query = new GetEventsDetailsQuery { Id = eventId };
+        var query = new GetEventsDetailsQuery
+        {
+            Id = eventId,
+            PageSize = pageNumber,
+            PageNumber = pageSize
+        };
 
         return await mediator.Send(query, cancellationToken);
     }
@@ -155,11 +174,18 @@ public class EventsController(IMediator mediator) : ControllerBase
         Summary = "Get event participation",
         Description = "Retrieves participation details for a specific event."
     )]
-    public async Task<ResultT<IEnumerable<EventsWithParticipationInEventsDTos>>> GetEventsWithParticipationInEventAsync(
+    public async Task<ResultT<PagedResult<EventsWithParticipationInEventsDTos>>> GetEventsWithParticipationInEventAsync(
         [FromRoute] Guid eventId,
+        [FromQuery] int pageNumber,
+        [FromQuery] int pageSize,
         CancellationToken cancellationToken)
     {
-        var query = new GetEventsWithParticipationInEventQuery { EventsId = eventId };
+        var query = new GetEventsWithParticipationInEventQuery
+        {
+            EventsId = eventId,
+            PageNumber = pageNumber,
+            PageSize = pageSize
+        };
 
         return await mediator.Send(query, cancellationToken);
     }
@@ -170,10 +196,17 @@ public class EventsController(IMediator mediator) : ControllerBase
         Summary = "Order events",
         Description = "Retrieves events ordered by the specified field."
     )]
-    public async Task<ResultT<IEnumerable<EventsDto>>> OrderByIdAsync([FromQuery] string orderBy,
+    public async Task<ResultT<PagedResult<EventsDto>>> OrderByIdAsync([FromQuery] string orderBy,
+        [FromQuery] int pageNumber,
+        [FromQuery] int pageSize,
         CancellationToken cancellationToken)
     {
-        var query = new GetOrderByIdEventsQuery { Order = orderBy };
+        var query = new GetOrderByIdEventsQuery
+        {
+            Order = orderBy,
+            PageNumber = pageNumber,
+            PageSize = pageSize
+        };
 
         return await mediator.Send(query, cancellationToken);
     }


### PR DESCRIPTION
## Description

This PR introduces pagination improvements by replacing plain list returns with `PagedResult` across repositories, controllers, and tests.  
The goal is to provide a more consistent and extensible way of handling paginated responses throughout the application.

## Changes Included

- **Repository**
  - Refactored methods to return `PagedResult<T>` instead of raw lists.
- **Controller**
  - Updated endpoints to return `PagedResult` responses.
- **Tests**
  - Adjusted and added unit tests to validate `PagedResult` behavior.
- **Chore**
  - Minor update: added null checks in parameters.

## Motivation

Previously, repositories and controllers returned raw lists, which made it harder to handle pagination consistently.  
By introducing `PagedResult`, the application now supports:
- Page number & size tracking
- Total item count
- Consistent response structure for clients

## Checklist

- [x] Repository methods updated to return `PagedResult`
- [x] Controllers adapted to expose `PagedResult` in endpoints
- [x] Tests updated and passing
- [x] Parameter handling improved
