### PR TITLE
Authentication & JWT Enhancements

### DIFF
--- a/MetaBond.Infrastructure.Shared/DependencyInjection.cs
+++ b/MetaBond.Infrastructure.Shared/DependencyInjection.cs
@@ -1,5 +1,6 @@
 ﻿using MetaBond.Application.DTOs.Account.Auth;
 using MetaBond.Application.Interfaces.Service;
+using MetaBond.Application.Interfaces.Service.Auth;
 using MetaBond.Domain.Settings;
 using MetaBond.Infrastructure.Shared.Service;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
@@ -27,6 +28,7 @@ namespace MetaBond.Infrastructure.Shared
 
             services.AddScoped<ICloudinaryService, CloudinaryService>();
             services.AddScoped<IEmailService, EmailService>();
+            services.AddScoped<IJwtService, JwtService>();
 
             #endregion
 
@@ -50,9 +52,8 @@ namespace MetaBond.Infrastructure.Shared
                     ClockSkew = TimeSpan.Zero,
                     ValidIssuer = configuration["JwtSettings:Issuer"],
                     ValidAudience = configuration["JwtSettings:Audience"],
-                    IssuerSigningKey =
-                        new SymmetricSecurityKey(
-                            System.Text.Encoding.UTF8.GetBytes(configuration["JwtSettings:Key"] ?? string.Empty)),
+                    IssuerSigningKey = new SymmetricSecurityKey(
+                        Convert.FromBase64String(configuration["JwtSettings:Key"] ?? string.Empty)),
                     // Explicitly validate the algorithm
                     RequireSignedTokens = true,
                     ValidAlgorithms = [SecurityAlgorithms.HmacSha256]

--- a/MetaBond.Infrastructure.Shared/Service/JwtService.cs
+++ b/MetaBond.Infrastructure.Shared/Service/JwtService.cs
@@ -1,6 +1,5 @@
 using System.IdentityModel.Tokens.Jwt;
 using System.Security.Claims;
-using System.Text;
 using MetaBond.Application.DTOs.Account.Auth;
 using MetaBond.Application.Interfaces.Service.Auth;
 using MetaBond.Application.Utils;
@@ -79,10 +78,10 @@ public class JwtService(IOptions<JwtSettings> jwtSettings) : IJwtService
         ValidateSettings();
         var claims = new List<Claim>
         {
-            new Claim(JwtRegisteredClaimNames.Sub, user.Id.ToString()),
+            new Claim(JwtRegisteredClaimNames.Sub, community.Id.ToString()),
             new Claim(JwtRegisteredClaimNames.Jti, Guid.NewGuid().ToString()),
-            new Claim(ClaimTypes.Email, user.Email ?? string.Empty),
             new Claim(ClaimTypes.Role, role),
+            new Claim("userId", user.Id.ToString()),
             new Claim("communityId", community.CommunityId.ToString()),
             new Claim("type", CommunityType)
         };
@@ -103,7 +102,7 @@ public class JwtService(IOptions<JwtSettings> jwtSettings) : IJwtService
             ValidateIssuerSigningKey = true,
             ValidIssuer = _jwtSettings.Issuer,
             ValidAudience = _jwtSettings.Audience,
-            IssuerSigningKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(_jwtSettings.Key ?? string.Empty)),
+            IssuerSigningKey = new SymmetricSecurityKey(Convert.FromBase64String(_jwtSettings.Key ?? string.Empty)),
             ValidateLifetime = false // Allow expired tokens
         };
         var tokenHandler = new JwtSecurityTokenHandler();
@@ -210,7 +209,7 @@ public class JwtService(IOptions<JwtSettings> jwtSettings) : IJwtService
 
     private string BuildToken(IEnumerable<Claim> claims, TimeSpan expiresIn)
     {
-        var key = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(_jwtSettings.Key ?? string.Empty));
+        var key = new SymmetricSecurityKey(Convert.FromBase64String(_jwtSettings.Key ?? string.Empty));
         var credentials = new SigningCredentials(key, SecurityAlgorithms.HmacSha256);
 
         var token = new JwtSecurityToken(

--- a/MetaBond.Presentation.Api/Controllers/V1/AuthController.cs
+++ b/MetaBond.Presentation.Api/Controllers/V1/AuthController.cs
@@ -1,0 +1,93 @@
+using Asp.Versioning;
+using MediatR;
+using MetaBond.Application.DTOs.Account.Auth;
+using MetaBond.Application.Feature.Authentication.Commands.GenerateCommunityToken;
+using MetaBond.Application.Feature.Authentication.Commands.LoginAdmin;
+using MetaBond.Application.Feature.Authentication.Commands.LoginUser;
+using MetaBond.Application.Feature.Authentication.Commands.RefreshTokenAdmin;
+using MetaBond.Application.Feature.Authentication.Commands.RefreshTokenUser;
+using MetaBond.Application.Utils;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.RateLimiting;
+using Swashbuckle.AspNetCore.Annotations;
+
+namespace MetaBond.Presentation.Api.Controllers.V1;
+
+[ApiController]
+[ApiVersion("1.0")]
+[Route("api/v{version:ApiVersion}/auth")]
+public class AuthController(IMediator mediator) : ControllerBase
+{
+    [HttpPost("users")]
+    [EnableRateLimiting("fixed")]
+    [SwaggerOperation(
+        Summary = "Login a user",
+        Description = "Authenticates a user and returns an access token and a refresh token."
+    )]
+    public async Task<ResultT<AuthenticationResponse>> LoginUserAsync(
+        [FromBody] LoginUserCommand command,
+        CancellationToken cancellationToken)
+    {
+        return await mediator.Send(command, cancellationToken);
+    }
+
+    [HttpPost("admin")]
+    [EnableRateLimiting("fixed")]
+    [SwaggerOperation(
+        Summary = "Login an admin",
+        Description = "Authenticates an admin and returns an access token and a refresh token."
+    )]
+    public async Task<ResultT<AuthenticationResponse>> LoginAdminAsync(
+        [FromBody] LoginAdminCommand command,
+        CancellationToken cancellationToken)
+    {
+        return await mediator.Send(command, cancellationToken);
+    }
+
+    [HttpPost("refresh-token/users")]
+    [EnableRateLimiting("fixed")]
+    [SwaggerOperation(
+        Summary = "Refresh a user token",
+        Description = "Refreshes the access token and refresh token for a user using a valid refresh token."
+    )]
+    public async Task<ResultT<AuthenticationResponse>> RefreshTokenUserAsync(
+        [FromBody] RefreshTokenUserCommand command,
+        CancellationToken cancellationToken)
+    {
+        return await mediator.Send(command, cancellationToken);
+    }
+
+    [HttpPost("refresh-token/admin")]
+    [EnableRateLimiting("fixed")]
+    [SwaggerOperation(
+        Summary = "Refresh an admin token",
+        Description = "Refreshes the access token and refresh token for an admin using a valid refresh token."
+    )]
+    public async Task<ResultT<AuthenticationResponse>> RefreshTokenAdminAsync(
+        [FromBody] RefreshTokenAdminCommand command,
+        CancellationToken cancellationToken)
+    {
+        return await mediator.Send(command, cancellationToken);
+    }
+
+    [HttpPost("communities/{communityId}/users/{userId}/token")]
+    [EnableRateLimiting("fixed")]
+    [SwaggerOperation(
+        Summary = "Generate community token",
+        Description =
+            "Generates a JWT for a specific user in a specific community, including the user's role in that community."
+    )]
+    public async Task<ResultT<AuthenticationCommunityResponse>> GenerateCommunityTokenAsync(
+        [FromRoute] Guid communityId,
+        [FromRoute] Guid userId,
+        CancellationToken cancellationToken = default)
+    {
+        var command = new GenerateCommunityTokenCommand
+        {
+            CommunityId = communityId,
+            UserId = userId
+        };
+
+        return await mediator.Send(command, cancellationToken);
+    }
+}

--- a/MetaBond.Presentation.Api/Extensions/ServiceExtension.cs
+++ b/MetaBond.Presentation.Api/Extensions/ServiceExtension.cs
@@ -52,7 +52,7 @@ public static class ServiceExtension
             options.AddFixedWindowLimiter("fixed", limiterOptions =>
             {
                 limiterOptions.Window = TimeSpan.FromMinutes(1);
-                limiterOptions.PermitLimit = 8;
+                limiterOptions.PermitLimit = 20;
             });
 
             options.AddSlidingWindowLimiter("sliding", limiterOptions =>


### PR DESCRIPTION

## Summary
This PR introduces the authentication layer for the application, including JWT-based token management for users, admins, and community memberships. It also refactors JWT key handling and updates rate-limiting configuration. These changes establish a secure and extendable foundation for user authentication and authorization.

## Changes
### Authentication
- **feat(auth): add AuthController**  
  Implements endpoints for:
  - User login (`POST /api/v{version}/auth/users`)
  - Admin login (`POST /api/v{version}/auth/admin`)
  - Refresh tokens for users and admins
  - Generating JWT tokens for community memberships (`POST /api/v{version}/auth/communities/{communityId}/users/{userId}/token`)

- **feat(auth): add JwtService**  
  Provides methods to generate access and refresh tokens for:
  - Users
  - Admins
  - Community memberships  
  Includes handling of token claims (`sub`, `jti`, `role`, `type`, `communityId`).

- **build(auth): register JwtService in DI container**  
  Registers `JwtService` in the dependency injection container for use in command handlers.

- **refactor(auth): generate base64 key**  
  Refactors JWT secret key generation to use Base64 encoding for improved security.

### Rate Limiting
- **chore(rate-limiting): add new limiter options configuration**  
  Updates the rate-limiting configuration to support new policies and better control over API request flow.

## Notes
- Authentication handlers now use `IJwtService` via DI for token generation.
- Refresh tokens are differentiated from access tokens using the `"type"` claim.
- Community membership tokens require validation of both user and community membership.
- Expiration times for access and refresh tokens are configured via `JwtSettings`.

## Testing
- Endpoints were tested via Swagger and Postman.
- Tokens generated for users, admins, and communities have correct claims and expiration.
- Rate limiting applies correctly to authentication endpoints.
